### PR TITLE
fix: handle empty value for select property

### DIFF
--- a/src/Pages/Properties/Option.php
+++ b/src/Pages/Properties/Option.php
@@ -51,7 +51,7 @@ class Option
 
         $id = $array["id"] ?? null;
         $name = $array["name"] ?? null;
-        $color = $array["color"];
+        $color = $array["color"] ?? self::COLOR_DEFAULT;
 
         return new self($id, $name, $color);
     }

--- a/src/Pages/Properties/Select.php
+++ b/src/Pages/Properties/Select.php
@@ -46,7 +46,7 @@ class Select implements PropertyInterface
         /** @psalm-var SelectJson $array */
         $property = Property::fromArray($array);
 
-        $option = Option::fromArray($array[self::TYPE]);
+        $option = Option::fromArray($array[self::TYPE] ?? []);
 
         return new self($property, $option);
     }


### PR DESCRIPTION
If the a select property is empty the 
```
Notion\Pages\Properties\Option::fromArray(): Argument #1 ($array) must be of type array, null given, called in /vendor/mariosimao/notion-sdk-php/src/Pages/Properties/Select.php on line 49
````