### PR TITLE
Add URL support to RichText objects

### DIFF
--- a/src/Common/RichText.php
+++ b/src/Common/RichText.php
@@ -192,6 +192,19 @@ class RichText
         );
     }
 
+    public function withUrl(string $url): self
+    {
+        return new self(
+            $this->plainText,
+            $this->href,
+            $this->annotations,
+            $this->type,
+            $this->text->withUrl($url),
+            $this->mention,
+            $this->equation,
+        );
+    }
+
     public function withAnnotations(Annotations $annotations): self
     {
         return new self(

--- a/src/Common/RichText.php
+++ b/src/Common/RichText.php
@@ -53,25 +53,45 @@ class RichText
     /** @psalm-mutation-free */
     public static function createText(string $content): self
     {
-        $annotations = Annotations::create();
         $text = Text::create($content);
 
-        return new self($content, null, $annotations, "text", $text, null, null);
+        return self::createFromText($text);
+    }
+
+    public static function createLink(string $content, string $url): self
+    {
+        $text = Text::create($content)->withUrl($url);
+
+        return self::createFromText($text);
+    }
+
+    /** @psalm-mutation-free */
+    public static function createFromText(Text $text): self
+    {
+        $annotations = Annotations::create();
+
+        return new self($text->content(), $text->url(), $annotations, "text", $text, null, null);
     }
 
     public static function createEquation(string $expression): self
     {
-        $annotations = Annotations::create();
         $equation = Equation::create($expression);
 
+        return self::createFromEquation($equation);
+    }
+
+    public static function createFromEquation(Equation $equation): self
+    {
+        $annotations = Annotations::create();
+
         return new self(
-            $expression,
+            $equation->expression(),
             null,
             $annotations,
             "equation",
             null,
             null,
-            $equation,
+            $equation
         );
     }
 
@@ -187,19 +207,6 @@ class RichText
             $this->annotations,
             $this->type,
             $this->text,
-            $this->mention,
-            $this->equation,
-        );
-    }
-
-    public function withUrl(string $url): self
-    {
-        return new self(
-            $this->plainText,
-            $this->href,
-            $this->annotations,
-            $this->type,
-            $this->text->withUrl($url),
             $this->mention,
             $this->equation,
         );

--- a/tests/Unit/Common/RichTextTest.php
+++ b/tests/Unit/Common/RichTextTest.php
@@ -2,7 +2,9 @@
 
 namespace Notion\Test\Unit\Common;
 
+use Notion\Common\Equation;
 use Notion\Common\RichText;
+use Notion\Common\Text;
 use PHPUnit\Framework\TestCase;
 
 class RichTextTest extends TestCase
@@ -16,12 +18,43 @@ class RichTextTest extends TestCase
         $this->assertEquals("Simple text", $richText->text()?->content());
     }
 
+    public function test_create_link(): void
+    {
+        $richText = RichText::createLink("Click here", "https://notion.so");
+
+        $this->assertTrue($richText->isText());
+        $this->assertEquals("Click here", $richText->plainText());
+        $this->assertEquals("Click here", $richText->text()?->content());
+        $this->assertEquals("https://notion.so", $richText->href());
+        $this->assertEquals("https://notion.so", $richText->text()?->url());
+    }
+
+    public function test_create_from_text(): void
+    {
+        $text = Text::create("My text");
+
+        $richText = RichText::createFromText($text);
+
+        $this->assertTrue($richText->isText());
+        $this->assertEquals("My text", $richText->plainText());
+        $this->assertEquals("My text", $richText->text()?->content());
+    }
+
     public function test_create_equation(): void
     {
         $richText = RichText::createEquation("a^2 + b^2 = c^2");
 
         $this->assertTrue($richText->isEquation());
         $this->assertEquals("equation", $richText->type());
+        $this->assertEquals("a^2 + b^2 = c^2", $richText->equation()?->expression());
+    }
+
+    public function test_create_from_equation(): void
+    {
+        $equation = Equation::create("a^2 + b^2 = c^2");
+        $richText = RichText::createFromEquation($equation);
+
+        $this->assertTrue($richText->isEquation());
         $this->assertEquals("a^2 + b^2 = c^2", $richText->equation()?->expression());
     }
 
@@ -67,18 +100,11 @@ class RichTextTest extends TestCase
         $this->assertEquals("red", $richText->annotations()->color());
     }
 
-    public function test_add_link(): void
+    public function test_change_href(): void
     {
         $richText = RichText::createText("Simple text")->withHref("https://notion.so");
 
         $this->assertEquals("https://notion.so", $richText->href());
-    }
-
-    public function test_add_url(): void
-    {
-        $richText = RichText::createText("Simple text")->withUrl("https://my-site.com");
-
-        $this->assertEquals("https://my-site.com", $richText->text()->url());
     }
 
     public function test_mention_array_conversion(): void

--- a/tests/Unit/Common/RichTextTest.php
+++ b/tests/Unit/Common/RichTextTest.php
@@ -74,6 +74,13 @@ class RichTextTest extends TestCase
         $this->assertEquals("https://notion.so", $richText->href());
     }
 
+    public function test_add_url(): void
+    {
+        $richText = RichText::createText("Simple text")->withUrl("https://my-site.com");
+
+        $this->assertEquals("https://my-site.com", $richText->text()->url());
+    }
+
     public function test_mention_array_conversion(): void
     {
         $array = [


### PR DESCRIPTION
This PR intends to fix #88 by adding the ability to create RichText objects with URLs.

This approach isn't exactly pure and effectively requires RichText to be a superset of Text, i.e. support everything that Text supports. An alternative might be to allow `RichText::createText(string $content)` to also support `Text` objects, hence allowing `RichText` to be created from `string` or `Text`.