### PR TITLE
[Feature] relation filter

### DIFF
--- a/src/Databases/Query/RelationFilter.php
+++ b/src/Databases/Query/RelationFilter.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Notion\Databases\Query;
+
+/** @psalm-immutable */
+class RelationFilter implements Filter, Condition
+{
+    private static array $validOperators = [
+        Operator::Contains,
+        Operator::DoesNotContain,
+        Operator::IsEmpty,
+        Operator::IsNotEmpty,
+    ];
+
+
+    private function __construct(
+        private readonly string $propertyName,
+        private readonly Operator $operator,
+        private readonly string|bool $value,
+    ) {
+        if (!in_array($operator, self::$validOperators)) {
+            throw new \Exception("Invalid operator");
+        }
+    }
+
+    public static function property(string $propertyName): self
+    {
+        return new self(
+            $propertyName,
+            Operator::IsNotEmpty,
+            true
+        );
+    }
+
+    /** @return "property" */
+    public function propertyType(): string
+    {
+        return 'property';
+    }
+
+    public function propertyName(): string
+    {
+        return $this->propertyName;
+    }
+
+    public function operator(): Operator
+    {
+        return $this->operator;
+    }
+
+    public function value(): string|bool
+    {
+        return $this->value;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            $this->propertyType() => $this->propertyName,
+            "relation" => [
+                $this->operator->value => $this->value
+            ],
+        ];
+    }
+
+    public function contains(string $value): self
+    {
+        return new self($this->propertyName, Operator::Contains, $value);
+    }
+
+    public function doesNotContain(string $value): self
+    {
+        return new self($this->propertyName, Operator::DoesNotContain, $value);
+    }
+
+    public function isEmpty(): self
+    {
+        return new self($this->propertyName, Operator::IsEmpty, true);
+    }
+
+    public function isNotEmpty(): self
+    {
+        return new self($this->propertyName, Operator::IsNotEmpty, true);
+    }
+}

--- a/tests/Unit/Databases/Query/RelationFilterTest.php
+++ b/tests/Unit/Databases/Query/RelationFilterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Notion\Test\Unit\Databases\Query;
+
+use Notion\Databases\Query\Operator;
+use Notion\Databases\Query\RelationFilter;
+use PHPUnit\Framework\TestCase;
+
+class RelationFilterTest extends TestCase
+{
+    public function test_empty_filter(): void
+    {
+        $filter = RelationFilter::property("Category");
+
+        $this->assertSame("Category", $filter->propertyName());
+        $this->assertSame(Operator::IsNotEmpty, $filter->operator());
+        $this->assertTrue($filter->value());
+    }
+
+    public function test_contains(): void
+    {
+        $filter = RelationFilter::property("Category")->contains("Blog");
+
+        $expected = [
+            "property" => "Category",
+            "relation" => [ "contains" => "Blog" ],
+        ];
+        $this->assertSame($expected, $filter->toArray());
+    }
+
+    public function test_does_not_contain(): void
+    {
+        $filter = RelationFilter::property("Category")->doesNotContain("Blog");
+
+        $expected = [
+            "property" => "Category",
+            "relation" => [ "does_not_contain" => "Blog" ],
+        ];
+        $this->assertSame($expected, $filter->toArray());
+    }
+
+    public function test_is_empty(): void
+    {
+        $filter = RelationFilter::property("Category")->isEmpty();
+
+        $expected = [
+            "property" => "Category",
+            "relation" => [ "is_empty" => true ],
+        ];
+        $this->assertSame($expected, $filter->toArray());
+    }
+
+    public function test_is_not_empty(): void
+    {
+        $filter = RelationFilter::property("Category")->isNotEmpty();
+
+        $expected = [
+            "property" => "Category",
+            "relation" => [ "is_not_empty" => true ],
+        ];
+        $this->assertSame($expected, $filter->toArray());
+    }
+}


### PR DESCRIPTION
# Why this PR exists?
This pull request includes a new feature which is RelationFilter for database querying. It provides us filtering the pages according to their relations.

## How to use it?
Usage is quite basic. Here an example:
```php
$database = $client->databases()->find('< DB_ID >');

$query = Query::create()
    ->changeFilter(
        CompoundFilter::and(
            DateFilter::property('delivery_date')->onOrBefore(date('Y-m-d')),
            RelationFilter::property('Project')->contains('< PAGE_ID >'),
        )
    )
    ->addSort(Sort::property("delivery_date")->ascending())
    ->changePageSize(30);

$result = $client->databases()->query($database, $query);
```