### PR TITLE
fix(database): using empty objects instead of empty arrays for date filtering

### DIFF
--- a/src/Databases/Query/DateFilter.php
+++ b/src/Databases/Query/DateFilter.php
@@ -2,6 +2,8 @@
 
 namespace Notion\Databases\Query;
 
+use stdClass;
+
 /** @psalm-immutable */
 class DateFilter implements Filter, Condition
 {
@@ -32,7 +34,7 @@ class DateFilter implements Filter, Condition
         private readonly string $propertyType,
         private readonly string $propertyName,
         private readonly Operator $operator,
-        private readonly string|bool|array|object $value,
+        private readonly string|bool|array|stdClass $value,
     ) {
         if (!in_array($operator, self::$validOperators)) {
             throw new \Exception("Invalid operator");
@@ -84,7 +86,7 @@ class DateFilter implements Filter, Condition
         return $this->operator;
     }
 
-    public function value(): string|bool|array|object
+    public function value(): string|bool|array|stdClass
     {
         return $this->value;
     }
@@ -136,36 +138,36 @@ class DateFilter implements Filter, Condition
 
     public function pastWeek(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::PastWeek, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::PastWeek, new stdClass());
     }
 
     public function pastMonth(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::PastMonth, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::PastMonth, new stdClass());
     }
 
     public function pastYear(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::PastYear, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::PastYear, new stdClass());
     }
 
     public function nextWeek(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::NextWeek, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::NextWeek, new stdClass());
     }
 
     public function nextMonth(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::NextMonth, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::NextMonth, new stdClass());
     }
 
     public function nextYear(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::NextYear, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::NextYear, new stdClass());
     }
 
     public function thisWeek(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::ThisWeek, (object) []);
+        return new self($this->propertyType, $this->propertyName, Operator::ThisWeek, new stdClass());
     }
 }

--- a/src/Databases/Query/DateFilter.php
+++ b/src/Databases/Query/DateFilter.php
@@ -32,7 +32,7 @@ class DateFilter implements Filter, Condition
         private readonly string $propertyType,
         private readonly string $propertyName,
         private readonly Operator $operator,
-        private readonly string|bool|array $value,
+        private readonly string|bool|array|object $value,
     ) {
         if (!in_array($operator, self::$validOperators)) {
             throw new \Exception("Invalid operator");
@@ -84,7 +84,7 @@ class DateFilter implements Filter, Condition
         return $this->operator;
     }
 
-    public function value(): string|bool|array
+    public function value(): string|bool|array|object
     {
         return $this->value;
     }
@@ -136,36 +136,36 @@ class DateFilter implements Filter, Condition
 
     public function pastWeek(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::PastWeek, []);
+        return new self($this->propertyType, $this->propertyName, Operator::PastWeek, (object) []);
     }
 
     public function pastMonth(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::PastMonth, []);
+        return new self($this->propertyType, $this->propertyName, Operator::PastMonth, (object) []);
     }
 
     public function pastYear(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::PastYear, []);
+        return new self($this->propertyType, $this->propertyName, Operator::PastYear, (object) []);
     }
 
     public function nextWeek(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::NextWeek, []);
+        return new self($this->propertyType, $this->propertyName, Operator::NextWeek, (object) []);
     }
 
     public function nextMonth(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::NextMonth, []);
+        return new self($this->propertyType, $this->propertyName, Operator::NextMonth, (object) []);
     }
 
     public function nextYear(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::NextYear, []);
+        return new self($this->propertyType, $this->propertyName, Operator::NextYear, (object) []);
     }
 
     public function thisWeek(): self
     {
-        return new self($this->propertyType, $this->propertyName, Operator::ThisWeek, []);
+        return new self($this->propertyType, $this->propertyName, Operator::ThisWeek, (object) []);
     }
 }

--- a/tests/Unit/Databases/Query/CompoundFilterTest.php
+++ b/tests/Unit/Databases/Query/CompoundFilterTest.php
@@ -25,11 +25,11 @@ class CompoundFilterTest extends TestCase
                 ],
                 [
                     "timestamp" => "created_time",
-                    "date" => [ "past_week" => [] ],
+                    "date" => [ "past_week" => (object) [] ],
                 ],
             ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_or(): void
@@ -47,11 +47,11 @@ class CompoundFilterTest extends TestCase
                 ],
                 [
                     "timestamp" => "created_time",
-                    "date" => [ "past_week" => [] ],
+                    "date" => [ "past_week" => (object) [] ],
                 ],
             ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_nested(): void

--- a/tests/Unit/Databases/Query/CompoundFilterTest.php
+++ b/tests/Unit/Databases/Query/CompoundFilterTest.php
@@ -7,6 +7,7 @@ use Notion\Databases\Query\DateFilter;
 use Notion\Databases\Query\SelectFilter;
 use Notion\Databases\Query\TextFilter;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class CompoundFilterTest extends TestCase
 {
@@ -25,7 +26,7 @@ class CompoundFilterTest extends TestCase
                 ],
                 [
                     "timestamp" => "created_time",
-                    "date" => [ "past_week" => (object) [] ],
+                    "date" => [ "past_week" => new stdClass() ],
                 ],
             ],
         ];
@@ -47,7 +48,7 @@ class CompoundFilterTest extends TestCase
                 ],
                 [
                     "timestamp" => "created_time",
-                    "date" => [ "past_week" => (object) [] ],
+                    "date" => [ "past_week" => new stdClass() ],
                 ],
             ],
         ];

--- a/tests/Unit/Databases/Query/DateFilterTest.php
+++ b/tests/Unit/Databases/Query/DateFilterTest.php
@@ -5,6 +5,7 @@ namespace Notion\Test\Unit\Databases\Query;
 use Notion\Databases\Query\DateFilter;
 use Notion\Databases\Query\Operator;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class DateFilterTest extends TestCase
 {
@@ -129,7 +130,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "past_week" => (object) [] ],
+            "date" => [ "past_week" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }
@@ -141,7 +142,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "past_month" => (object) [] ],
+            "date" => [ "past_month" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }
@@ -153,7 +154,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "past_year" => (object) [] ],
+            "date" => [ "past_year" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }
@@ -165,7 +166,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "next_week" => (object) [] ],
+            "date" => [ "next_week" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }
@@ -177,7 +178,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "next_month" => (object) [] ],
+            "date" => [ "next_month" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }
@@ -189,7 +190,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "next_year" => (object) [] ],
+            "date" => [ "next_year" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }
@@ -201,7 +202,7 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "this_week" => (object) [] ],
+            "date" => [ "this_week" => new stdClass() ],
         ];
         $this->assertEquals($expected, $filter->toArray());
     }

--- a/tests/Unit/Databases/Query/DateFilterTest.php
+++ b/tests/Unit/Databases/Query/DateFilterTest.php
@@ -129,9 +129,9 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "past_week" => [] ],
+            "date" => [ "past_week" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_past_month(): void
@@ -141,9 +141,9 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "past_month" => [] ],
+            "date" => [ "past_month" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_past_year(): void
@@ -153,9 +153,9 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "past_year" => [] ],
+            "date" => [ "past_year" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_next_week(): void
@@ -165,9 +165,9 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "next_week" => [] ],
+            "date" => [ "next_week" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_next_month(): void
@@ -177,9 +177,9 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "next_month" => [] ],
+            "date" => [ "next_month" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_next_year(): void
@@ -189,9 +189,9 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "next_year" => [] ],
+            "date" => [ "next_year" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 
     public function test_this_week(): void
@@ -201,8 +201,8 @@ class DateFilterTest extends TestCase
 
         $expected = [
             "property" => "Release date",
-            "date" => [ "this_week" => [] ],
+            "date" => [ "this_week" => (object) [] ],
         ];
-        $this->assertSame($expected, $filter->toArray());
+        $this->assertEquals($expected, $filter->toArray());
     }
 }


### PR DESCRIPTION
- The `DateFilter` class was modified to accept an object as a value in addition to string, bool, and array.
- The tests for `CompoundFilter` and `DateFilter` were updated to use objects instead of empty arrays for the `past_week`, `past_month`, `past_year`, `next_week`, `next_month`, `next_year`, and `this_week` properties in the `date` array. The tests were also updated to use `assertEquals` instead of `assertSame` for the expected and actual arrays.

see more: [https://developers.notion.com/reference/post-database-query-filter#date](https://developers.notion.com/reference/post-database-query-filter#date)