### PR TITLE
Add number_with_commas to NumberFormat enum

### DIFF
--- a/src/Databases/Properties/NumberFormat.php
+++ b/src/Databases/Properties/NumberFormat.php
@@ -6,6 +6,7 @@ enum NumberFormat: string
 {
     case Number = "number";
     case NumberChangeCommas = "number_change_commas";
+    case NumberWithCommas = "number_with_commas";
     case Percent = "percent";
     case Dollar = "dollar";
     case CanadianDollar = "canadian_dollar";


### PR DESCRIPTION
for my database i have a column with `number_with_commas` number format

```
"Count": {
	"id": "%3Dk%60U",
	"name": "Count",
	"type": "number",
	"number": {
		"format": "number_with_commas"
	}
},
```

i getting this exception :

```
"number_with_commas" is not a valid backing value for enum "Notion\Databases\Properties\NumberFormat"
```

this PR solve this bug