### PR TITLE
(bugfix) Refactor property type in DateFilter for filtering on created_time and last_edited_time + fix documentation

### DIFF
--- a/docs/how-to/query-database.md
+++ b/docs/how-to/query-database.md
@@ -19,7 +19,7 @@ $database = $notion->databases()->find($databaseId);
 $query = Query::create()
     ->changeFilter(
         CompoundFilter::and(
-            DateFilter::createdTime::pastWeek(),
+            DateFilter::createdTime()->pastWeek(),
             TextFilter::property("Name")->contains("John"),
         )
     )

--- a/src/Databases/Query/DateFilter.php
+++ b/src/Databases/Query/DateFilter.php
@@ -93,9 +93,11 @@ class DateFilter implements Filter, Condition
 
     public function toArray(): array
     {
+        $type = $this->propertyType === self::TYPE_PROPERTY ? "date" : $this->propertyName;
+
         return [
             $this->propertyType() => $this->propertyName,
-            "date" => [
+            $type => [
                 $this->operator->value => $this->value
             ],
         ];


### PR DESCRIPTION
## Current situation
* Documentation uses static constant which will not work: https://x.gnx.li/s61hn2G2
* If you use it correctly the call fails because the `date` type may not be used when using the 2 fixed timestamps (https://developers.notion.com/reference/post-database-query-filter#timestamp)

## Proposed solution
* Check if property is timestamp and use proprtyname as type when it is