### PR TITLE
Add missing methods changeXXX to some properties to have a more consistent API accross properties.

### DIFF
--- a/src/Databases/Properties/StatusOption.php
+++ b/src/Databases/Properties/StatusOption.php
@@ -64,4 +64,9 @@ class StatusOption
 
         return $option;
     }
+
+    public function changeName(string $name): self
+    {
+        return new self($this->id, $name, $this->color);
+    }
 }

--- a/src/Pages/Properties/Date.php
+++ b/src/Pages/Properties/Date.php
@@ -71,6 +71,11 @@ class Date implements PropertyInterface
         return $this->metadata;
     }
 
+    public function changeDate(CommonDate $date): self
+    {
+        return new self($this->metadata, $date);
+    }
+
     public function changeStart(DateTimeImmutable $start): self
     {
         return new self($this->metadata, $this->date?->changeStart($start));

--- a/src/Pages/Properties/MultiSelect.php
+++ b/src/Pages/Properties/MultiSelect.php
@@ -85,4 +85,12 @@ class MultiSelect implements PropertyInterface
             array_filter($this->options, fn (SelectOption $o) => $o->id !== $optionId),
         );
     }
+
+    public function changeOptions(array $options): self
+    {
+        return new self(
+            $this->metadata,
+            array_filter($options, fn ($o) => $o instanceof SelectOption),
+        );
+    }
 }

--- a/src/Pages/Properties/MultiSelect.php
+++ b/src/Pages/Properties/MultiSelect.php
@@ -86,11 +86,8 @@ class MultiSelect implements PropertyInterface
         );
     }
 
-    public function changeOptions(array $options): self
+    public function changeOptions(SelectOption ...$options): self
     {
-        return new self(
-            $this->metadata,
-            array_filter($options, fn ($o) => $o instanceof SelectOption),
-        );
+        return new self($this->metadata, $options);
     }
 }

--- a/src/Pages/Properties/Status.php
+++ b/src/Pages/Properties/Status.php
@@ -74,4 +74,9 @@ class Status implements PropertyInterface
     {
         return $this->metadata;
     }
+
+    public function changeOption(StatusOption $option): self
+    {
+        return new self($this->metadata, $option);
+    }
 }


### PR DESCRIPTION
Most Pages/Properties classes have a `changeXXX` method but some properties don't.
This PR add a `changeXXX` property to the following classes
- `Pages/Properties/Date` : `changeDate`
- `Pages/Properties/MultiSelect` : `changeOptions`
- `Pages/Properties/Status` : `changeOption` (same as Select)

A changeName is also added to the `Databases/Properties/StatusOption` class as it already exists on the `SelectOption` class.