### PR TITLE
Add PropertyMetadata's Description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A complete Notion SDK for PHP developers.",
     "type": "library",
     "license": "MIT",
-    "homepage": "https:/mariosimao.github.io/notion-sdk-php",
+    "homepage": "https://mariosimao.github.io/notion-sdk-php",
     "autoload": {
         "psr-4": {
             "Notion\\": "src/"

--- a/src/Databases/Properties/Checkbox.php
+++ b/src/Databases/Properties/Checkbox.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "checkbox",
  *      checkbox: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/CreatedBy.php
+++ b/src/Databases/Properties/CreatedBy.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "created_by",
  *      created_by: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/CreatedTime.php
+++ b/src/Databases/Properties/CreatedTime.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "created_time",
  *      created_time: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Date.php
+++ b/src/Databases/Properties/Date.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "date",
  *      date: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Email.php
+++ b/src/Databases/Properties/Email.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "email",
  *      email: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Files.php
+++ b/src/Databases/Properties/Files.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "files",
  *      file: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Formula.php
+++ b/src/Databases/Properties/Formula.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "formula",
  *      formula: array{ expression: string },
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/LastEditedBy.php
+++ b/src/Databases/Properties/LastEditedBy.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "last_edited_by",
  *      last_edited_by: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/LastEditedTime.php
+++ b/src/Databases/Properties/LastEditedTime.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "last_edited_time",
  *      last_edited_time: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/MultiSelect.php
+++ b/src/Databases/Properties/MultiSelect.php
@@ -12,6 +12,7 @@ namespace Notion\Databases\Properties;
  *      multi_select: array{
  *          options: list<SelectOptionJson>
  *      },
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Number.php
+++ b/src/Databases/Properties/Number.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "number",
  *      number: array{ format: string },
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/People.php
+++ b/src/Databases/Properties/People.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "people",
  *      people: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/PhoneNumber.php
+++ b/src/Databases/Properties/PhoneNumber.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "phone_number",
  *      phone_number: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/PropertyMetadata.php
+++ b/src/Databases/Properties/PropertyMetadata.php
@@ -3,7 +3,7 @@
 namespace Notion\Databases\Properties;
 
 /**
- * @psalm-type PropertyMetadataJson = array{ id: string, name: string, type: string, ... }
+ * @psalm-type PropertyMetadataJson = array{ id: string, name: string, type: string, description?: string, ... }
  *
  * @psalm-immutable
  */
@@ -14,12 +14,13 @@ class PropertyMetadata
         public readonly string $name,
         public readonly PropertyType $type,
         private readonly string|null $unknownType = null,
+        public readonly string|null $description = null,
     ) {
     }
 
-    public static function create(string $id, string $name, PropertyType $type): self
+    public static function create(string $id, string $name, PropertyType $type, ?string $description = null): self
     {
-        return new self($id, $name, $type);
+        return new self($id, $name, $type, description: $description);
     }
 
     /**
@@ -36,6 +37,7 @@ class PropertyMetadata
             $array["name"],
             $type,
             $type === PropertyType::Unknown ? $array["type"] : null,
+            $array["description"] ?? null,
         );
     }
 
@@ -47,6 +49,9 @@ class PropertyMetadata
             "id"   => $this->id,
             "name" => $this->name,
             "type" => $type,
+            ...($this->description !== null ? [
+                "description" => $this->description,
+            ] : []),
         ];
     }
 }

--- a/src/Databases/Properties/Relation.php
+++ b/src/Databases/Properties/Relation.php
@@ -17,7 +17,8 @@ use Notion\Exceptions\RelationException;
  *              synced_property_name: string,
  *              synced_property_id: string
  *          }
- *      }
+ *      },
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/RichTextProperty.php
+++ b/src/Databases/Properties/RichTextProperty.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "rich_text",
  *      rich_text: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Select.php
+++ b/src/Databases/Properties/Select.php
@@ -12,6 +12,7 @@ namespace Notion\Databases\Properties;
  *      select: array{
  *          options: list<SelectOptionJson>
  *      },
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/SelectOption.php
+++ b/src/Databases/Properties/SelectOption.php
@@ -8,7 +8,8 @@ use Notion\Common\Color;
  * @psalm-type SelectOptionJson = array{
  *      id?: string,
  *      name?: string,
- *      color?: string
+ *      color?: string,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Status.php
+++ b/src/Databases/Properties/Status.php
@@ -14,6 +14,7 @@ namespace Notion\Databases\Properties;
  *          options: StatusOptionJson[],
  *          groups: StatusGroupJson[]
  *      },
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/StatusGroup.php
+++ b/src/Databases/Properties/StatusGroup.php
@@ -9,7 +9,8 @@ use Notion\Common\Color;
  *      id?: string,
  *      name?: string,
  *      color: string,
- *      option_ids: string[]
+ *      option_ids: string[],
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/StatusOption.php
+++ b/src/Databases/Properties/StatusOption.php
@@ -8,7 +8,8 @@ use Notion\Common\Color;
  * @psalm-type StatusOptionJson = array{
  *      id?: string,
  *      name?: string,
- *      color?: string
+ *      color?: string,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Title.php
+++ b/src/Databases/Properties/Title.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "title",
  *      title: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/UniqueId.php
+++ b/src/Databases/Properties/UniqueId.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "uniqueId",
  *      unique_id: \stdClass,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Unknown.php
+++ b/src/Databases/Properties/Unknown.php
@@ -6,7 +6,8 @@ namespace Notion\Databases\Properties;
  * @psalm-type PropertyJson = array{
  *      id: string,
  *      name: string,
- *      type: string
+ *      type: string,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/src/Databases/Properties/Url.php
+++ b/src/Databases/Properties/Url.php
@@ -8,6 +8,7 @@ namespace Notion\Databases\Properties;
  *      name: string,
  *      type: "url",
  *      url: array<empty, empty>,
+ *      description?: string,
  * }
  *
  * @psalm-immutable

--- a/tests/Unit/Databases/Properties/CreatedByTest.php
+++ b/tests/Unit/Databases/Properties/CreatedByTest.php
@@ -24,6 +24,7 @@ class CreatedByTest extends TestCase
             "name"  => "dummy",
             "type"  => "created_by",
             "created_by" => new \stdClass(),
+            "description" => "foo bar",
         ];
         $createdBy = CreatedBy::fromArray($array);
         $fromFactory = PropertyFactory::fromArray($array);

--- a/tests/Unit/Databases/Properties/PropertyMetadataTest.php
+++ b/tests/Unit/Databases/Properties/PropertyMetadataTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Notion\Test\Unit\Databases\Properties;
+
+use Notion\Databases\Properties\PropertyMetadata;
+use Notion\Databases\Properties\PropertyType;
+use PHPUnit\Framework\TestCase;
+
+class PropertyMetadataTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $metadata = PropertyMetadata::create("abc", "Dummy prop name", PropertyType::CreatedBy, "foo bar");
+
+        $this->assertEquals("abc", $metadata->id);
+        $this->assertEquals("Dummy prop name", $metadata->name);
+        $this->assertEquals(PropertyType::CreatedBy, $metadata->type);
+        $this->assertEquals("foo bar", $metadata->description);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "id"    => "abc",
+            "name"  => "dummy",
+            "type"  => "created_by",
+            "created_by" => new \stdClass(),
+            "description" => "foo bar",
+        ];
+        $metadata = PropertyMetadata::fromArray($array);
+
+        $this->assertEquals($array["id"], $metadata->id);
+        $this->assertEquals($array["name"], $metadata->name);
+        $this->assertEquals(PropertyType::CreatedBy, $metadata->type);
+        $this->assertEquals($array["description"], $metadata->description);
+
+        $toArray = $metadata->toArray();
+
+        $this->assertEqualsCanonicalizing(['id', 'name', 'type', 'description'], array_keys($toArray));
+    }
+
+    public function test_from_array_without_description(): void
+    {
+        $array = [
+            "id"    => "abc",
+            "name"  => "dummy",
+            "type"  => "created_by",
+            "created_by" => new \stdClass(),
+        ];
+
+        $metadata = PropertyMetadata::fromArray($array);
+
+        $this->assertEquals($array["id"], $metadata->id);
+        $this->assertEquals($array["name"], $metadata->name);
+        $this->assertEquals(PropertyType::CreatedBy, $metadata->type);
+        $this->assertNull($metadata->description);
+
+        $toArray = $metadata->toArray();
+
+        // When there is no description, its key won't show up
+        $this->assertEqualsCanonicalizing(['id', 'name', 'type'], array_keys($toArray));
+    }
+}


### PR DESCRIPTION
This PR will add the `description` property for a table's property.

I don't know how recent Notion added this feature, but I noticed it only one or two months ago.

[Here is the API documentation about it](https://developers.notion.com/reference/property-object), and here is how it looks in Notion's UI:
![image](https://github.com/mariosimao/notion-sdk-php/assets/2080215/b40a748a-9f62-4625-8e5a-ece6aa2b1381)

The API will not send the description if it was not filled, so I tried to follow the same behaviour when doing `toArray()`.
![image](https://github.com/mariosimao/notion-sdk-php/assets/2080215/d84b7fbc-a651-42c0-becc-15882f41c962)

I couldn't find anything that would make it backwards compatible, and the fact that all existing tests pass is a good hint I guess.
Let me know if something is missing!