### PR TITLE
Add support for file_upload type

### DIFF
--- a/src/Common/File.php
+++ b/src/Common/File.php
@@ -8,9 +8,10 @@ use DateTimeImmutable;
  * @psalm-import-type RichTextJson from \Notion\Common\RichText
  *
  * @psalm-type FileJson = array{
- *      type: "external"|"file",
+ *      type: "external"|"file"|"file_upload",
  *      file?: array{ url: string, expiry_time: string },
  *      external?: array{ url: string },
+ *      file_upload?: array{ id: string },
  *      name?: string,
  *      caption?: list<RichTextJson>
  * }
@@ -22,7 +23,8 @@ class File
     /** @param RichText[] $caption */
     private function __construct(
         public readonly FileType $type,
-        public readonly string $url,
+        public readonly string|null $url,
+        public readonly string|null $fileId,
         public readonly DateTimeImmutable|null $expiryTime,
         public readonly string|null $name,
         public readonly array $caption,
@@ -31,14 +33,19 @@ class File
 
     public static function createExternal(string $url): self
     {
-        return new self(FileType::External, $url, null, null, []);
+        return new self(FileType::External, $url, null, null, null, []);
     }
 
     public static function createInternal(
         string $url,
         DateTimeImmutable|null $expiryTime = null
     ): self {
-        return new self(FileType::Internal, $url, $expiryTime, null, []);
+        return new self(FileType::Internal, $url, null, $expiryTime, null, []);
+    }
+
+    public static function createFileUpload(string $fileId): self
+    {
+        return new self(FileType::FileUpload, null, $fileId, null, null, []);
     }
 
     /**
@@ -55,6 +62,7 @@ class File
         return new self(
             FileType::from($type),
             $file["url"] ?? "",
+            $file["id"] ?? "",
             isset($file["expiry_time"]) ? new DateTimeImmutable($file["expiry_time"]) : null,
             $array["name"] ?? null,
             isset($array["caption"]) ? array_map(fn($c) => RichText::fromArray($c), $array["caption"]) : [],
@@ -73,6 +81,13 @@ class File
                     "url" => $this->url,
                     "expiry_time" => $this->expiryTime?->format(Date::FORMAT),
                 ],
+            ];
+        }
+
+        if ($type === FileType::FileUpload) {
+            $array = [
+                "type" => "file_upload",
+                "file_upload" => [ "id" => $this->fileId ],
             ];
         }
 
@@ -104,18 +119,28 @@ class File
         return $this->type === FileType::Internal;
     }
 
+    public function isFileUpload(): bool
+    {
+        return $this->type === FileType::FileUpload;
+    }
+
     public function changeUrl(string $url): self
     {
-        return new self($this->type, $url, $this->expiryTime, $this->name, $this->caption);
+        return new self($this->type, $url, null, $this->expiryTime, $this->name, $this->caption);
+    }
+
+    public function changeFileUploadId(string $fileId): self
+    {
+        return new self($this->type, null, $fileId, $this->expiryTime, $this->name, $this->caption);
     }
 
     public function changeName(string $name): self
     {
-        return new self($this->type, $this->url, $this->expiryTime, $name, $this->caption);
+        return new self($this->type, $this->url, $this->fileId, $this->expiryTime, $name, $this->caption);
     }
 
     public function changeCaption(RichText ...$caption): self
     {
-        return new self($this->type, $this->url, $this->expiryTime, $this->name, $caption);
+        return new self($this->type, $this->url, $this->fileId, $this->expiryTime, $this->name, $caption);
     }
 }

--- a/src/Common/FileType.php
+++ b/src/Common/FileType.php
@@ -6,4 +6,5 @@ enum FileType: string
 {
     case Internal = "file";
     case External = "external";
+    case FileUpload = "file_upload";
 }


### PR DESCRIPTION
Notion recently added the ability to upload objects (eg: images, pdf, etc), and then use them directly in pages by using the uploaded object's id in the block object. This PR adds support for this filetype as part of an image block.

```
{
	"type": "image",
	"image": {
		"type": "file_upload",
		"file_upload": {
			"id": "{$FILE_UPLOAD_ID}"
		}
	}
}
```

https://developers.notion.com/reference/file-object
https://developers.notion.com/docs/uploading-small-files

I was unsure how to add upload functionality within this SDK. My attempts at using the built-in http client failed, so I created my own NotionApi object with this static function to handle the upload, and return the upload id. This example is CakePHP-based

```
	/**
	 * @return string The Notion file ID of the uploaded image
	 */
	public static function addImage(string $imageLocation, string $imageName): string
	{
		/** @var string $apiKey **/
		$apiKey = Configure::read('App.notionApiKey');

		// Create a Guzzle client
		$headers = [
			'Authorization' => "Bearer {$apiKey}",
			'Notion-Version' => '2022-06-28',
		];

		$client = new GuzzleHttp\Client([
			'base_uri' => 'https://api.notion.com',
			'headers' => $headers,
		]);

		// Submit file_upload request to get file upload URL and Id
		$resp = $client->request('POST', '/v1/file_uploads', [
			'json' => [
				'mode' => 'single_part',
				'filename' => $imageName,
				'content_type' => 'image/png',
			],
		]);

		if ($resp->getStatusCode() !== 200) {
			throw new Exception('Unable to get Notion Upload ID');
		}

		// Parse response
		$body = $resp->getBody();

		/** @var array{upload_url: string} $uploadInfo */
		$uploadInfo = json_decode($body->getContents(), associative: true);
		$uploadUrl  = $uploadInfo['upload_url'];

		// Upload image to provided URL
		$resp = $client->request('POST', $uploadUrl, [
			'multipart' => [
				[
					'name' => 'file',
					'contents' => GuzzleHttp\Psr7\Utils::tryFopen($imageLocation, 'rb'),
				],
			],
		]);

		if ($resp->getStatusCode() !== 200) {
			throw new Exception('Failed to upload image to Notion');
		}

		$body = $resp->getBody();

		/** @var array{id: string} $fileInfo */
		$fileInfo = json_decode($body->getContents(), associative: true);

		Log::debug("Notion Image Id: {$fileInfo['id']}");

		return $fileInfo['id'];
	}
```
