### PR TITLE
fix: handle missing workspace_limits in Bot::fromArray

### DIFF
--- a/src/Users/Bot.php
+++ b/src/Users/Bot.php
@@ -26,7 +26,7 @@ class Bot
      */
     public static function fromArray(array $array): self
     {
-        $workspaceLimits = WorkspaceLimits::fromArray($array["workspace_limits"]);
+        $workspaceLimits = WorkspaceLimits::fromArray($array["workspace_limits"] ?? []);
 
         return new self($workspaceLimits);
     }


### PR DESCRIPTION
Fixes [#415](https://github.com/mariosimao/notion-sdk-php/issues/415)

This PR fixes Client throws fatal error in cases when `$bot` in `Notion\Users::fromArray` is null or lacks workspace_limits field. The change adds a null coalescing operator to default to an empty array when the key is missing, preventing a PHP warning and type error.