### PR TITLE
fix: ValueError when parsing rich text mentions of type custom_emoji

### DIFF
--- a/src/Common/CustomEmoji.php
+++ b/src/Common/CustomEmoji.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Notion\Common;
+
+/**
+ * @psalm-type CustomEmojiJson = array{ id: string, name: string, url: string }
+ *
+ * @psalm-immutable
+ */
+class CustomEmoji
+{
+    private function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly string $url,
+    ) {
+    }
+
+    /**
+     * @psalm-param CustomEmojiJson $array
+     *
+     * @internal
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self($array["id"], $array["name"], $array["url"]);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            "id"   => $this->id,
+            "name" => $this->name,
+            "url"  => $this->url,
+        ];
+    }
+}

--- a/src/Common/Mention.php
+++ b/src/Common/Mention.php
@@ -7,13 +7,15 @@ use Notion\Users\User;
 /**
  * @psalm-import-type UserJson from \Notion\Users\User
  * @psalm-import-type DateJson from Date
+ * @psalm-import-type CustomEmojiJson from CustomEmoji
  *
  * @psalm-type MentionJson = array{
- *      type: "page"|"database"|"user"|"date",
+ *      type: "page"|"database"|"user"|"date"|"custom_emoji",
  *      page?: array{ id: string },
  *      database?: array{ id: string },
  *      user?: UserJson,
  *      date?: DateJson,
+ *      custom_emoji?: CustomEmojiJson,
  * }
  *
  * @psalm-immutable
@@ -26,27 +28,33 @@ class Mention
         public readonly string|null $databaseId,
         public readonly User|null $user,
         public readonly Date|null $date,
+        public readonly CustomEmoji|null $customEmoji,
     ) {
     }
 
     public static function page(string $pageId): self
     {
-        return new self(MentionType::Page, $pageId, null, null, null);
+        return new self(MentionType::Page, $pageId, null, null, null, null);
     }
 
     public static function database(string $databaseId): self
     {
-        return new self(MentionType::Database, null, $databaseId, null, null);
+        return new self(MentionType::Database, null, $databaseId, null, null, null);
     }
 
     public static function user(User $user): self
     {
-        return new self(MentionType::User, null, null, $user, null);
+        return new self(MentionType::User, null, null, $user, null, null);
     }
 
     public static function date(Date $date): self
     {
-        return new self(MentionType::Date, null, null, null, $date);
+        return new self(MentionType::Date, null, null, null, $date, null);
+    }
+
+    public static function customEmoji(CustomEmoji $customEmoji): self
+    {
+        return new self(MentionType::CustomEmoji, null, null, null, null, $customEmoji);
     }
 
     /**
@@ -62,8 +70,11 @@ class Mention
         $databaseId = array_key_exists("database", $array) ? $array["database"]["id"] : null;
         $user = array_key_exists("user", $array) ? User::fromArray($array["user"]) : null;
         $date = array_key_exists("date", $array) ? Date::fromArray($array["date"]) : null;
+        $customEmoji = array_key_exists("custom_emoji", $array)
+            ? CustomEmoji::fromArray($array["custom_emoji"])
+            : null;
 
-        return new self($type, $pageId, $databaseId, $user, $date);
+        return new self($type, $pageId, $databaseId, $user, $date, $customEmoji);
     }
 
     public function toArray(): array
@@ -81,6 +92,9 @@ class Mention
         }
         if ($this->isDate()) {
             $array["date"] = $this->date->toArray();
+        }
+        if ($this->isCustomEmoji()) {
+            $array["custom_emoji"] = $this->customEmoji->toArray();
         }
 
         return $array;
@@ -116,5 +130,13 @@ class Mention
     public function isDate(): bool
     {
         return $this->type === MentionType::Date;
+    }
+
+    /**
+     * @psalm-assert-if-true CustomEmoji $this->customEmoji
+     */
+    public function isCustomEmoji(): bool
+    {
+        return $this->type === MentionType::CustomEmoji;
     }
 }

--- a/src/Common/MentionType.php
+++ b/src/Common/MentionType.php
@@ -8,4 +8,5 @@ enum MentionType: string
     case Database = "database";
     case User = "user";
     case Date = "date";
+    case CustomEmoji = "custom_emoji";
 }

--- a/tests/Unit/Common/MentionTest.php
+++ b/tests/Unit/Common/MentionTest.php
@@ -3,6 +3,7 @@
 namespace Notion\Test\Unit\Common;
 
 use DateTimeImmutable;
+use Notion\Common\CustomEmoji;
 use Notion\Common\Date;
 use Notion\Common\Mention;
 use Notion\Common\MentionType;
@@ -54,6 +55,21 @@ class MentionTest extends TestCase
         $this->assertEquals($date, $mention->date);
     }
 
+    public function test_mention_custom_emoji(): void
+    {
+        $customEmoji = CustomEmoji::fromArray([
+            "id"   => "3219c080-1a17-8064-8f64-007a13443768",
+            "name" => "custom_estate_home_1",
+            "url"  => "https://example.com/custom-emoji.png",
+        ]);
+
+        $mention = Mention::customEmoji($customEmoji);
+
+        $this->assertTrue($mention->isCustomEmoji());
+        $this->assertEquals(MentionType::CustomEmoji, $mention->type);
+        $this->assertEquals($customEmoji, $mention->customEmoji);
+    }
+
     public function test_page_array_conversion(): void
     {
         $array = [
@@ -99,6 +115,21 @@ class MentionTest extends TestCase
         $array = [
             "type" => "date",
             "date" => [ "start" => "2021-01-01T00:00:00.000000Z", "end" => null ],
+        ];
+        $mention = Mention::fromArray($array);
+
+        $this->assertEquals($array, $mention->toArray());
+    }
+
+    public function test_custom_emoji_array_conversion(): void
+    {
+        $array = [
+            "type" => "custom_emoji",
+            "custom_emoji" => [
+                "id"   => "3219c080-1a17-8064-8f64-007a13443768",
+                "name" => "custom_estate_home_1",
+                "url"  => "https://example.com/custom-emoji.png",
+            ],
         ];
         $mention = Mention::fromArray($array);
 

--- a/tests/Unit/Common/RichTextTest.php
+++ b/tests/Unit/Common/RichTextTest.php
@@ -135,6 +135,35 @@ class RichTextTest extends TestCase
         $this->assertNotNull($richText->mention);
     }
 
+    public function test_custom_emoji_mention_array_conversion(): void
+    {
+        $array = [
+            "plain_text" => ":custom_estate_home_1:",
+            "href" => null,
+            "annotations" => [
+                "bold"          => false,
+                "italic"        => false,
+                "strikethrough" => false,
+                "underline"     => false,
+                "code"          => false,
+                "color"         => "default",
+            ],
+            "type" => "mention",
+            "mention" => [
+                "type" => "custom_emoji",
+                "custom_emoji" => [
+                    "id"   => "3219c080-1a17-8064-8f64-007a13443768",
+                    "name" => "custom_estate_home_1",
+                    "url"  => "https://example.com/custom-emoji.png",
+                ],
+            ],
+        ];
+        $richText = RichText::fromArray($array);
+
+        $this->assertEquals($array, $richText->toArray());
+        $this->assertTrue($richText->mention?->isCustomEmoji());
+    }
+
     public function test_equation_array_conversion(): void
     {
         $array = [


### PR DESCRIPTION
Fixes #425

## Problem

Notion's API can return rich-text mentions of type `custom_emoji` (a workspace custom emoji referenced inline in text). `Notion\Common\MentionType` did not define this case, so `Mention::fromArray()` threw:

```
ValueError: "custom_emoji" is not a valid backing value for enum Notion\Common\MentionType
```

Since this happens during `Page::fromArray()`, a single custom-emoji mention anywhere in a database made the whole `databases()->query()` call fail.

## Changes

- Add `MentionType::CustomEmoji` case.
- New `Notion\Common\CustomEmoji` value object (`id`, `name`, `url`), following the style of `Emoji`/`Equation`.
- Wire it into `Mention`: `customEmoji` property, `Mention::customEmoji()` static constructor, `isCustomEmoji()`, and `fromArray()`/`toArray()` support.

The payload shape (`{ id, name, url }` under the `custom_emoji` key) was captured from a real production API response.

## Tests

- `MentionTest`: creation via `Mention::customEmoji()` + array round-trip conversion.
- `RichTextTest`: regression test parsing a full rich-text element containing a `custom_emoji` mention (the exact failing path from the issue).

`composer test` (phpcs, psalm, phpunit Unit) passes on PHP 8.1 and 8.3; infection reports no escaped or uncovered mutants on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
