### PR TITLE
fix: rename tests after data sources introduction

### DIFF
--- a/tests/Unit/Search/FilterTest.php
+++ b/tests/Unit/Search/FilterTest.php
@@ -17,7 +17,7 @@ class FilterTest extends TestCase
         $this->assertSame(FilterProperty::Object, $f->property);
     }
 
-    public function test_by_databases(): void
+    public function test_by_data_sources(): void
     {
         $f = Filter::byDataSources();
 

--- a/tests/Unit/Search/QueryTest.php
+++ b/tests/Unit/Search/QueryTest.php
@@ -34,7 +34,7 @@ class QueryTest extends TestCase
         $this->assertSame(FilterValue::Page, $q->filter?->value);
     }
 
-    public function test_filter_by_databases(): void
+    public function test_filter_by_data_sources(): void
     {
         $q = Query::title("Term")->filterByDataSources();
 


### PR DESCRIPTION
Closes #432 