### PR TITLE
feat: support public OAuth integrations (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add typed `Authentication` client and models for public OAuth integrations (#443).
-  - Add `Notion\Authentication\Client` accessible via `$notion->authentication($clientId, $clientSecret)` with `createToken()`, `refreshToken()`, `introspectToken()`, and `revokeToken()` methods.
-  - Add `Notion\Authentication\TokenResponse` representing token responses from code exchange and token refresh, modeling `bot_id` as the unique installation identifier to support multiple installations per workspace.
-  - Add `Notion\Authentication\Owner` and `Notion\Authentication\OwnerType` representing user-level or workspace-level ownership.
-  - Add `Notion\Authentication\ExternalAccount` for specifying external account metadata when creating tokens.
-  - Add `Notion\Authentication\TokenIntrospection` representing token introspection status.
 - Add `Notion\DataSources\Query\RelativeDate` enum for relative date filter conditions (#199).
   - Supported relative dates: `Today`, `Tomorrow`, `Yesterday`, `OneWeekAgo`, `OneWeekFromNow`, `OneMonthAgo`, and `OneMonthFromNow`.
   - `DateFilter` methods `equals()`, `before()`, `after()`, `onOrBefore()`, and `onOrAfter()` accept `RelativeDate` instances in addition to `DateTimeImmutable`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add typed `Authentication` client and models for public OAuth integrations (#443).
+  - Add `Notion\Authentication\Client` accessible via `$notion->authentication()` with `createToken()`, `refreshToken()`, `introspectToken()`, and `revokeToken()` methods.
+  - Add `Notion\Authentication\TokenResponse` representing token responses from code exchange and token refresh, modeling `bot_id` as the unique installation identifier to support multiple installations per workspace.
+  - Add `Notion\Authentication\Owner` and `Notion\Authentication\OwnerType` representing user-level or workspace-level ownership.
+  - Add `Notion\Authentication\ExternalAccount` for specifying external account metadata when creating tokens.
+  - Add `Notion\Authentication\TokenIntrospection` representing token introspection status.
 - Add `Notion\DataSources\Query\RelativeDate` enum for relative date filter conditions (#199).
   - Supported relative dates: `Today`, `Tomorrow`, `Yesterday`, `OneWeekAgo`, `OneWeekFromNow`, `OneMonthAgo`, and `OneMonthFromNow`.
   - `DateFilter` methods `equals()`, `before()`, `after()`, `onOrBefore()`, and `onOrAfter()` accept `RelativeDate` instances in addition to `DateTimeImmutable`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add typed `Authentication` client and models for public OAuth integrations (#443).
-  - Add `Notion\Authentication\Client` accessible via `$notion->authentication()` with `createToken()`, `refreshToken()`, `introspectToken()`, and `revokeToken()` methods.
+  - Add `Notion\Authentication\Client` accessible via `$notion->authentication($clientId, $clientSecret)` with `createToken()`, `refreshToken()`, `introspectToken()`, and `revokeToken()` methods.
   - Add `Notion\Authentication\TokenResponse` representing token responses from code exchange and token refresh, modeling `bot_id` as the unique installation identifier to support multiple installations per workspace.
   - Add `Notion\Authentication\Owner` and `Notion\Authentication\OwnerType` representing user-level or workspace-level ownership.
   - Add `Notion\Authentication\ExternalAccount` for specifying external account metadata when creating tokens.

--- a/src/Authentication/Client.php
+++ b/src/Authentication/Client.php
@@ -3,7 +3,6 @@
 namespace Notion\Authentication;
 
 use Notion\Configuration;
-use Notion\Exceptions\ApiException;
 use Notion\Infrastructure\Http;
 
 /**
@@ -40,11 +39,14 @@ final readonly class Client
             $body["external_account"] = $externalAccount->toArray();
         }
 
+        $url = "https://api.notion.com/v1/oauth/token";
+        $request = Http::createAuthRequest($url, $this->config, $this->clientId, $this->clientSecret)
+            ->withMethod("POST")
+            ->withHeader("Content-Type", "application/json");
+        $request->getBody()->write((string) json_encode($body));
+
         /** @psalm-var TokenResponseJson $responseBody */
-        $responseBody = $this->sendBasicAuthRequest(
-            "https://api.notion.com/v1/oauth/token",
-            $body,
-        );
+        $responseBody = Http::sendRequest($request, $this->config);
 
         return TokenResponse::fromArray($responseBody);
     }
@@ -56,11 +58,14 @@ final readonly class Client
             "refresh_token" => $refreshToken,
         ];
 
+        $url = "https://api.notion.com/v1/oauth/token";
+        $request = Http::createAuthRequest($url, $this->config, $this->clientId, $this->clientSecret)
+            ->withMethod("POST")
+            ->withHeader("Content-Type", "application/json");
+        $request->getBody()->write((string) json_encode($body));
+
         /** @psalm-var TokenResponseJson $responseBody */
-        $responseBody = $this->sendBasicAuthRequest(
-            "https://api.notion.com/v1/oauth/token",
-            $body,
-        );
+        $responseBody = Http::sendRequest($request, $this->config);
 
         return TokenResponse::fromArray($responseBody);
     }
@@ -71,11 +76,14 @@ final readonly class Client
             "token" => $token,
         ];
 
+        $url = "https://api.notion.com/v1/oauth/introspect";
+        $request = Http::createAuthRequest($url, $this->config, $this->clientId, $this->clientSecret)
+            ->withMethod("POST")
+            ->withHeader("Content-Type", "application/json");
+        $request->getBody()->write((string) json_encode($body));
+
         /** @psalm-var TokenIntrospectionJson $responseBody */
-        $responseBody = $this->sendBasicAuthRequest(
-            "https://api.notion.com/v1/oauth/introspect",
-            $body,
-        );
+        $responseBody = Http::sendRequest($request, $this->config);
 
         return TokenIntrospection::fromArray($responseBody);
     }
@@ -86,48 +94,12 @@ final readonly class Client
             "token" => $token,
         ];
 
-        $this->sendBasicAuthRequest(
-            "https://api.notion.com/v1/oauth/revoke",
-            $body,
-        );
-    }
-
-    /**
-     * @param array<string, mixed> $body
-     */
-    private function sendBasicAuthRequest(string $url, array $body): array
-    {
-        $encoded = base64_encode("{$this->clientId}:{$this->clientSecret}");
-        $auth = "Basic {$encoded}";
-
-        $request = $this->config->requestFactory
-            ->createRequest("POST", $url)
-            ->withHeader("Authorization", $auth)
-            ->withHeader("Notion-Version", $this->config->version)
+        $url = "https://api.notion.com/v1/oauth/revoke";
+        $request = Http::createAuthRequest($url, $this->config, $this->clientId, $this->clientSecret)
+            ->withMethod("POST")
             ->withHeader("Content-Type", "application/json");
-
         $request->getBody()->write((string) json_encode($body));
 
-        $response = $this->config->httpClient->sendRequest($request);
-
-        /** @var array */
-        $responseBody = json_decode((string) $response->getBody(), true);
-
-        if ($response->getStatusCode() >= 400) {
-            /** @var mixed $rawMessage */
-            $rawMessage = $responseBody["message"]
-                ?? $responseBody["error_description"]
-                ?? $responseBody["error"]
-                ?? "";
-            /** @var mixed $rawCode */
-            $rawCode = $responseBody["code"] ?? $responseBody["error"] ?? "";
-
-            $message = is_string($rawMessage) ? $rawMessage : "";
-            $code = is_string($rawCode) ? $rawCode : "";
-
-            throw new ApiException($message, $code, $response);
-        }
-
-        return $responseBody;
+        Http::sendRequest($request, $this->config);
     }
 }

--- a/src/Authentication/Client.php
+++ b/src/Authentication/Client.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Notion\Authentication;
+
+use Notion\Configuration;
+use Notion\Exceptions\ApiException;
+use Notion\Infrastructure\Http;
+
+/**
+ * @psalm-import-type TokenResponseJson from TokenResponse
+ * @psalm-import-type TokenIntrospectionJson from TokenIntrospection
+ */
+final readonly class Client
+{
+    /**
+     * @internal Use `\Notion\Notion::authentication()` instead
+     */
+    public function __construct(
+        private Configuration $config,
+    ) {
+    }
+
+    public function createToken(
+        string $code,
+        string|null $redirectUri = null,
+        ExternalAccount|null $externalAccount = null,
+    ): TokenResponse {
+        $body = [
+            "grant_type" => "authorization_code",
+            "code" => $code,
+        ];
+
+        if ($redirectUri !== null) {
+            $body["redirect_uri"] = $redirectUri;
+        }
+
+        if ($externalAccount !== null) {
+            $body["external_account"] = $externalAccount->toArray();
+        }
+
+        /** @psalm-var TokenResponseJson $responseBody */
+        $responseBody = $this->sendBasicAuthRequest(
+            "https://api.notion.com/v1/oauth/token",
+            $body,
+        );
+
+        return TokenResponse::fromArray($responseBody);
+    }
+
+    public function refreshToken(string $refreshToken): TokenResponse
+    {
+        $body = [
+            "grant_type" => "refresh_token",
+            "refresh_token" => $refreshToken,
+        ];
+
+        /** @psalm-var TokenResponseJson $responseBody */
+        $responseBody = $this->sendBasicAuthRequest(
+            "https://api.notion.com/v1/oauth/token",
+            $body,
+        );
+
+        return TokenResponse::fromArray($responseBody);
+    }
+
+    public function introspectToken(string $token): TokenIntrospection
+    {
+        $body = [
+            "token" => $token,
+        ];
+
+        /** @psalm-var TokenIntrospectionJson $responseBody */
+        $responseBody = $this->sendBasicAuthRequest(
+            "https://api.notion.com/v1/oauth/introspect",
+            $body,
+        );
+
+        return TokenIntrospection::fromArray($responseBody);
+    }
+
+    public function revokeToken(string $token): void
+    {
+        $body = [
+            "token" => $token,
+        ];
+
+        $this->sendBasicAuthRequest(
+            "https://api.notion.com/v1/oauth/revoke",
+            $body,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function sendBasicAuthRequest(string $url, array $body): array
+    {
+        $token = $this->config->token;
+        if (str_starts_with($token, "Basic ")) {
+            $auth = $token;
+        } else {
+            $credentials = str_contains($token, ":") ? base64_encode($token) : $token;
+            $auth = "Basic {$credentials}";
+        }
+
+        $request = $this->config->requestFactory
+            ->createRequest("POST", $url)
+            ->withHeader("Authorization", $auth)
+            ->withHeader("Notion-Version", $this->config->version)
+            ->withHeader("Content-Type", "application/json");
+
+        $request->getBody()->write((string) json_encode($body));
+
+        $response = $this->config->httpClient->sendRequest($request);
+
+        /** @var array */
+        $responseBody = json_decode((string) $response->getBody(), true);
+
+        if ($response->getStatusCode() >= 400) {
+            /** @var mixed $rawMessage */
+            $rawMessage = $responseBody["message"]
+                ?? $responseBody["error_description"]
+                ?? $responseBody["error"]
+                ?? "";
+            /** @var mixed $rawCode */
+            $rawCode = $responseBody["code"] ?? $responseBody["error"] ?? "";
+
+            $message = is_string($rawMessage) ? $rawMessage : "";
+            $code = is_string($rawCode) ? $rawCode : "";
+
+            throw new ApiException($message, $code, $response);
+        }
+
+        return $responseBody;
+    }
+}

--- a/src/Authentication/Client.php
+++ b/src/Authentication/Client.php
@@ -17,6 +17,8 @@ final readonly class Client
      */
     public function __construct(
         private Configuration $config,
+        public string $clientId,
+        public string $clientSecret,
     ) {
     }
 
@@ -95,13 +97,8 @@ final readonly class Client
      */
     private function sendBasicAuthRequest(string $url, array $body): array
     {
-        $token = $this->config->token;
-        if (str_starts_with($token, "Basic ")) {
-            $auth = $token;
-        } else {
-            $credentials = str_contains($token, ":") ? base64_encode($token) : $token;
-            $auth = "Basic {$credentials}";
-        }
+        $encoded = base64_encode("{$this->clientId}:{$this->clientSecret}");
+        $auth = "Basic {$encoded}";
 
         $request = $this->config->requestFactory
             ->createRequest("POST", $url)

--- a/src/Authentication/ExternalAccount.php
+++ b/src/Authentication/ExternalAccount.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Notion\Authentication;
+
+/**
+ * @psalm-type ExternalAccountJson = array{
+ *     key: string,
+ *     name: string,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class ExternalAccount
+{
+    private function __construct(
+        public string $key,
+        public string $name,
+    ) {
+    }
+
+    public static function create(string $key, string $name): self
+    {
+        return new self($key, $name);
+    }
+
+    /**
+     * @psalm-param ExternalAccountJson $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            key: $array["key"],
+            name: $array["name"],
+        );
+    }
+
+    /**
+     * @psalm-return ExternalAccountJson
+     */
+    public function toArray(): array
+    {
+        return [
+            "key" => $this->key,
+            "name" => $this->name,
+        ];
+    }
+}

--- a/src/Authentication/ExternalAccount.php
+++ b/src/Authentication/ExternalAccount.php
@@ -24,17 +24,6 @@ final readonly class ExternalAccount
     }
 
     /**
-     * @psalm-param ExternalAccountJson $array
-     */
-    public static function fromArray(array $array): self
-    {
-        return new self(
-            key: $array["key"],
-            name: $array["name"],
-        );
-    }
-
-    /**
      * @psalm-return ExternalAccountJson
      */
     public function toArray(): array

--- a/src/Authentication/Owner.php
+++ b/src/Authentication/Owner.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Notion\Authentication;
+
+use Notion\Users\User;
+
+/**
+ * @psalm-import-type UserJson from \Notion\Users\User
+ *
+ * @psalm-type OwnerJson = array{
+ *     type: "user"|"workspace",
+ *     user?: UserJson,
+ *     workspace?: true,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class Owner
+{
+    private function __construct(
+        public OwnerType $type,
+        public User|null $user = null,
+    ) {
+    }
+
+    public static function user(User $user): self
+    {
+        return new self(OwnerType::User, $user);
+    }
+
+    public static function workspace(): self
+    {
+        return new self(OwnerType::Workspace, null);
+    }
+
+    /**
+     * @psalm-param OwnerJson $array
+     */
+    public static function fromArray(array $array): self
+    {
+        $type = OwnerType::from($array["type"]);
+        $user = isset($array["user"]) ? User::fromArray($array["user"]) : null;
+
+        return new self($type, $user);
+    }
+
+    /**
+     * @psalm-assert-if-true User $this->user
+     */
+    public function isUser(): bool
+    {
+        return $this->type === OwnerType::User;
+    }
+
+    public function isWorkspace(): bool
+    {
+        return $this->type === OwnerType::Workspace;
+    }
+}

--- a/src/Authentication/Owner.php
+++ b/src/Authentication/Owner.php
@@ -23,16 +23,6 @@ final readonly class Owner
     ) {
     }
 
-    public static function user(User $user): self
-    {
-        return new self(OwnerType::User, $user);
-    }
-
-    public static function workspace(): self
-    {
-        return new self(OwnerType::Workspace, null);
-    }
-
     /**
      * @psalm-param OwnerJson $array
      */

--- a/src/Authentication/OwnerType.php
+++ b/src/Authentication/OwnerType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Notion\Authentication;
+
+enum OwnerType: string
+{
+    case User = "user";
+    case Workspace = "workspace";
+}

--- a/src/Authentication/TokenIntrospection.php
+++ b/src/Authentication/TokenIntrospection.php
@@ -22,15 +22,6 @@ final readonly class TokenIntrospection
     ) {
     }
 
-    public static function create(
-        bool $active,
-        string|null $scope = null,
-        int|null $iat = null,
-        string|null $requestId = null,
-    ): self {
-        return new self($active, $scope, $iat, $requestId);
-    }
-
     /**
      * @psalm-param TokenIntrospectionJson $array
      */
@@ -42,10 +33,5 @@ final readonly class TokenIntrospection
             iat: $array["iat"] ?? null,
             requestId: $array["request_id"] ?? null,
         );
-    }
-
-    public function isActive(): bool
-    {
-        return $this->active;
     }
 }

--- a/src/Authentication/TokenIntrospection.php
+++ b/src/Authentication/TokenIntrospection.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Notion\Authentication;
+
+/**
+ * @psalm-type TokenIntrospectionJson = array{
+ *     active: bool,
+ *     scope?: string|null,
+ *     iat?: int|null,
+ *     request_id?: string|null,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class TokenIntrospection
+{
+    private function __construct(
+        public bool $active,
+        public string|null $scope = null,
+        public int|null $iat = null,
+        public string|null $requestId = null,
+    ) {
+    }
+
+    public static function create(
+        bool $active,
+        string|null $scope = null,
+        int|null $iat = null,
+        string|null $requestId = null,
+    ): self {
+        return new self($active, $scope, $iat, $requestId);
+    }
+
+    /**
+     * @psalm-param TokenIntrospectionJson $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            active: $array["active"],
+            scope: $array["scope"] ?? null,
+            iat: $array["iat"] ?? null,
+            requestId: $array["request_id"] ?? null,
+        );
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+}

--- a/src/Authentication/TokenResponse.php
+++ b/src/Authentication/TokenResponse.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Notion\Authentication;
+
+/**
+ * @psalm-import-type OwnerJson from Owner
+ *
+ * @psalm-type TokenResponseJson = array{
+ *     access_token: string,
+ *     token_type?: string,
+ *     bot_id: string,
+ *     workspace_id: string,
+ *     workspace_name?: string|null,
+ *     workspace_icon?: string|null,
+ *     owner: OwnerJson,
+ *     duplicated_template_id?: string|null,
+ *     refresh_token?: string|null,
+ *     request_id?: string|null,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class TokenResponse
+{
+    private function __construct(
+        public string $accessToken,
+        public string $tokenType,
+        public string $botId,
+        public string $workspaceId,
+        public string|null $workspaceName,
+        public string|null $workspaceIcon,
+        public Owner $owner,
+        public string|null $duplicatedTemplateId = null,
+        public string|null $refreshToken = null,
+        public string|null $requestId = null,
+    ) {
+    }
+
+    public static function create(
+        string $accessToken,
+        string $botId,
+        string $workspaceId,
+        Owner $owner,
+        string $tokenType = "bearer",
+        string|null $workspaceName = null,
+        string|null $workspaceIcon = null,
+        string|null $duplicatedTemplateId = null,
+        string|null $refreshToken = null,
+        string|null $requestId = null,
+    ): self {
+        return new self(
+            $accessToken,
+            $tokenType,
+            $botId,
+            $workspaceId,
+            $workspaceName,
+            $workspaceIcon,
+            $owner,
+            $duplicatedTemplateId,
+            $refreshToken,
+            $requestId,
+        );
+    }
+
+    /**
+     * @psalm-param TokenResponseJson $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            accessToken: $array["access_token"],
+            tokenType: $array["token_type"] ?? "bearer",
+            botId: $array["bot_id"],
+            workspaceId: $array["workspace_id"],
+            workspaceName: $array["workspace_name"] ?? null,
+            workspaceIcon: $array["workspace_icon"] ?? null,
+            owner: Owner::fromArray($array["owner"]),
+            duplicatedTemplateId: $array["duplicated_template_id"] ?? null,
+            refreshToken: $array["refresh_token"] ?? null,
+            requestId: $array["request_id"] ?? null,
+        );
+    }
+}

--- a/src/Authentication/TokenResponse.php
+++ b/src/Authentication/TokenResponse.php
@@ -36,32 +36,6 @@ final readonly class TokenResponse
     ) {
     }
 
-    public static function create(
-        string $accessToken,
-        string $botId,
-        string $workspaceId,
-        Owner $owner,
-        string $tokenType = "bearer",
-        string|null $workspaceName = null,
-        string|null $workspaceIcon = null,
-        string|null $duplicatedTemplateId = null,
-        string|null $refreshToken = null,
-        string|null $requestId = null,
-    ): self {
-        return new self(
-            $accessToken,
-            $tokenType,
-            $botId,
-            $workspaceId,
-            $workspaceName,
-            $workspaceIcon,
-            $owner,
-            $duplicatedTemplateId,
-            $refreshToken,
-            $requestId,
-        );
-    }
-
     /**
      * @psalm-param TokenResponseJson $array
      */

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -32,9 +32,12 @@ class ApiException extends NotionException
             return new static("", "", $response);
         }
 
-        return match ($body["code"]) {
-            "conflict_error" => new ConflictException($body["message"], $body["code"], $response),
-            default          => new static($body["message"], $body["code"], $response),
+        $code = $body["code"] ?? "";
+        $message = $body["message"] ?? "";
+
+        return match ($code) {
+            "conflict_error" => new ConflictException($message, $code, $response),
+            default          => new static($message, $code, $response),
         };
     }
 }

--- a/src/Infrastructure/Http.php
+++ b/src/Infrastructure/Http.php
@@ -30,6 +30,18 @@ final readonly class Http
             ->withHeader("Notion-Version", $config->version);
     }
 
+    public static function createAuthRequest(
+        string $uri,
+        Configuration $config,
+        string $clientId,
+        string $clientSecret,
+    ): RequestInterface {
+        return $config->requestFactory
+            ->createRequest("GET", $uri)
+            ->withHeader("Authorization", "Basic " . base64_encode("{$clientId}:{$clientSecret}"))
+            ->withHeader("Notion-Version", $config->version);
+    }
+
     public static function sendRequest(
         RequestInterface $request,
         Configuration $config,

--- a/src/Notion.php
+++ b/src/Notion.php
@@ -2,6 +2,7 @@
 
 namespace Notion;
 
+use Notion\Authentication\Client as AuthenticationClient;
 use Notion\Blocks\Client as BlocksClient;
 use Notion\Comments\Client as CommentsClient;
 use Notion\Databases\Client as DatabasesClient;
@@ -86,5 +87,10 @@ final readonly class Notion
     public function fileUploads(): FileUploadsClient
     {
         return new FileUploadsClient($this->configuration);
+    }
+
+    public function authentication(): AuthenticationClient
+    {
+        return new AuthenticationClient($this->configuration);
     }
 }

--- a/src/Notion.php
+++ b/src/Notion.php
@@ -89,8 +89,8 @@ final readonly class Notion
         return new FileUploadsClient($this->configuration);
     }
 
-    public function authentication(): AuthenticationClient
+    public function authentication(string $clientId, string $clientSecret): AuthenticationClient
     {
-        return new AuthenticationClient($this->configuration);
+        return new AuthenticationClient($this->configuration, $clientId, $clientSecret);
     }
 }

--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -7,6 +7,12 @@ use Notion\Exceptions\ApiException;
 use Notion\Notion;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Proper integration tests are hard for the happy paths of the authentication client
+ * due to the need for real auth codes got from browser redirect.
+ * 
+ * The following tests cover failure scenarios with real connection to Notion API.
+ */
 class AuthenticationTest extends TestCase
 {
     public function test_create_token_invalid_code(): void

--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -11,46 +11,51 @@ class AuthenticationTest extends TestCase
 {
     public function test_create_token_invalid_code(): void
     {
-        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+        $notion = Notion::create("dummy_token");
 
         $this->expectException(ApiException::class);
-        $notion->authentication()->createToken("invalid_authorization_code");
+        $notion->authentication("dummy_client_id", "dummy_client_secret")
+            ->createToken("invalid_authorization_code");
     }
 
     public function test_create_token_with_external_account(): void
     {
-        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+        $notion = Notion::create("dummy_token");
         $externalAccount = ExternalAccount::create("acc_123", "Acme Corp");
 
         $this->expectException(ApiException::class);
-        $notion->authentication()->createToken(
-            code: "invalid_authorization_code",
-            redirectUri: "https://example.com/callback",
-            externalAccount: $externalAccount,
-        );
+        $notion->authentication("dummy_client_id", "dummy_client_secret")
+            ->createToken(
+                code: "invalid_authorization_code",
+                redirectUri: "https://example.com/callback",
+                externalAccount: $externalAccount,
+            );
     }
 
     public function test_refresh_token_invalid(): void
     {
-        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+        $notion = Notion::create("dummy_token");
 
         $this->expectException(ApiException::class);
-        $notion->authentication()->refreshToken("invalid_refresh_token");
+        $notion->authentication("dummy_client_id", "dummy_client_secret")
+            ->refreshToken("invalid_refresh_token");
     }
 
     public function test_introspect_token_invalid(): void
     {
-        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+        $notion = Notion::create("dummy_token");
 
         $this->expectException(ApiException::class);
-        $notion->authentication()->introspectToken("invalid_token");
+        $notion->authentication("dummy_client_id", "dummy_client_secret")
+            ->introspectToken("invalid_token");
     }
 
     public function test_revoke_token_invalid(): void
     {
-        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+        $notion = Notion::create("dummy_token");
 
         $this->expectException(ApiException::class);
-        $notion->authentication()->revokeToken("invalid_token");
+        $notion->authentication("dummy_client_id", "dummy_client_secret")
+            ->revokeToken("invalid_token");
     }
 }

--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Notion\Test\Integration;
+
+use Notion\Authentication\ExternalAccount;
+use Notion\Exceptions\ApiException;
+use Notion\Notion;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    public function test_create_token_invalid_code(): void
+    {
+        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+
+        $this->expectException(ApiException::class);
+        $notion->authentication()->createToken("invalid_authorization_code");
+    }
+
+    public function test_create_token_with_external_account(): void
+    {
+        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+        $externalAccount = ExternalAccount::create("acc_123", "Acme Corp");
+
+        $this->expectException(ApiException::class);
+        $notion->authentication()->createToken(
+            code: "invalid_authorization_code",
+            redirectUri: "https://example.com/callback",
+            externalAccount: $externalAccount,
+        );
+    }
+
+    public function test_refresh_token_invalid(): void
+    {
+        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+
+        $this->expectException(ApiException::class);
+        $notion->authentication()->refreshToken("invalid_refresh_token");
+    }
+
+    public function test_introspect_token_invalid(): void
+    {
+        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+
+        $this->expectException(ApiException::class);
+        $notion->authentication()->introspectToken("invalid_token");
+    }
+
+    public function test_revoke_token_invalid(): void
+    {
+        $notion = Notion::create("dummy_client_id:dummy_client_secret");
+
+        $this->expectException(ApiException::class);
+        $notion->authentication()->revokeToken("invalid_token");
+    }
+}

--- a/tests/Integration/AuthenticationTest.php
+++ b/tests/Integration/AuthenticationTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Proper integration tests are hard for the happy paths of the authentication client
  * due to the need for real auth codes got from browser redirect.
- * 
+ *
  * The following tests cover failure scenarios with real connection to Notion API.
  */
 class AuthenticationTest extends TestCase

--- a/tests/Unit/Authentication/ClientTest.php
+++ b/tests/Unit/Authentication/ClientTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Proper integration tests are hard for the happy paths of the authentication client
  * due to the need for real auth codes got from browser redirect.
- * 
+ *
  * The following tests cover the API Request format and response parsing.
  */
 class ClientTest extends TestCase

--- a/tests/Unit/Authentication/ClientTest.php
+++ b/tests/Unit/Authentication/ClientTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response;
 use Notion\Authentication\ExternalAccount;
 use Notion\Configuration;
+use Notion\Exceptions\ApiException;
 use Notion\Notion;
 use PHPUnit\Framework\TestCase;
 
@@ -204,6 +205,26 @@ class ClientTest extends TestCase
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string) $request->getBody(), true);
         $this->assertSame(["token" => "token_to_revoke"], $payload);
+    }
+
+    public function test_api_exception_thrown_on_error(): void
+    {
+        $errorResponse = [
+            "object" => "error",
+            "status" => 400,
+            "code" => "invalid_grant",
+            "message" => "The provided authorization code is invalid.",
+        ];
+
+        $mock = new MockHandler([
+            new Response(400, [], (string) json_encode($errorResponse)),
+        ]);
+        $client = $this->createNotionClient($mock);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage("The provided authorization code is invalid.");
+
+        $client->authentication("client_id", "client_secret")->createToken("invalid_code");
     }
 
     private function createNotionClient(MockHandler $mock, string $token = "test_token"): Notion

--- a/tests/Unit/Authentication/ClientTest.php
+++ b/tests/Unit/Authentication/ClientTest.php
@@ -185,7 +185,7 @@ class ClientTest extends TestCase
         $payload = json_decode((string) $request->getBody(), true);
         $this->assertSame(["token" => "token_to_check"], $payload);
 
-        $this->assertTrue($introspection->isActive());
+        $this->assertTrue($introspection->active);
         $this->assertSame("read:users", $introspection->scope);
         $this->assertSame(1710000000, $introspection->iat);
         $this->assertSame("req_introspect", $introspection->requestId);

--- a/tests/Unit/Authentication/ClientTest.php
+++ b/tests/Unit/Authentication/ClientTest.php
@@ -13,6 +13,12 @@ use Notion\Exceptions\ApiException;
 use Notion\Notion;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Proper integration tests are hard for the happy paths of the authentication client
+ * due to the need for real auth codes got from browser redirect.
+ * 
+ * The following tests cover the API Request format and response parsing.
+ */
 class ClientTest extends TestCase
 {
     public function test_create_token(): void

--- a/tests/Unit/Authentication/ClientTest.php
+++ b/tests/Unit/Authentication/ClientTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Notion\Test\Unit\Authentication;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use Notion\Authentication\ExternalAccount;
+use Notion\Configuration;
+use Notion\Notion;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function test_create_token(): void
+    {
+        $responseBody = [
+            "access_token" => "secret_oauth_token",
+            "token_type" => "bearer",
+            "bot_id" => "936998cb-aa55-46ff-b633-875c74239845",
+            "workspace_name" => "Acme Corp",
+            "workspace_icon" => "https://example.com/icon.png",
+            "workspace_id" => "787c805a-e7c6-48a6-9be8-1647895188f6",
+            "owner" => [
+                "type" => "user",
+                "user" => [
+                    "object" => "user",
+                    "id" => "123e4567-e89b-12d3-a456-426614174000",
+                    "name" => "Jane Doe",
+                ],
+            ],
+            "duplicated_template_id" => "550e8400-e29b-41d4-a716-446655440000",
+            "refresh_token" => "refresh_token_xyz",
+            "request_id" => "req_abc123",
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], (string) json_encode($responseBody)),
+        ]);
+        $client = $this->createNotionClient($mock, "my_client_id:my_client_secret");
+
+        $externalAccount = ExternalAccount::create("ext_key", "Ext Name");
+        $token = $client->authentication()->createToken(
+            code: "auth_code_123",
+            redirectUri: "https://example.com/callback",
+            externalAccount: $externalAccount,
+        );
+
+        $request = $mock->getLastRequest();
+        $this->assertNotNull($request);
+        $this->assertSame("POST", $request->getMethod());
+        $this->assertSame("https://api.notion.com/v1/oauth/token", (string) $request->getUri());
+        $expectedAuth = "Basic " . base64_encode("my_client_id:my_client_secret");
+        $this->assertSame($expectedAuth, $request->getHeaderLine("Authorization"));
+        $this->assertSame("application/json", $request->getHeaderLine("Content-Type"));
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getBody(), true);
+        $this->assertSame("authorization_code", $payload["grant_type"]);
+        $this->assertSame("auth_code_123", $payload["code"]);
+        $this->assertSame("https://example.com/callback", $payload["redirect_uri"]);
+        $this->assertSame(["key" => "ext_key", "name" => "Ext Name"], $payload["external_account"]);
+
+        $this->assertSame("secret_oauth_token", $token->accessToken);
+        $this->assertSame("bearer", $token->tokenType);
+        $this->assertSame("936998cb-aa55-46ff-b633-875c74239845", $token->botId);
+        $this->assertSame("787c805a-e7c6-48a6-9be8-1647895188f6", $token->workspaceId);
+        $this->assertSame("Acme Corp", $token->workspaceName);
+        $this->assertTrue($token->owner->isUser());
+        $this->assertSame("Jane Doe", $token->owner->user?->name);
+        $this->assertSame("550e8400-e29b-41d4-a716-446655440000", $token->duplicatedTemplateId);
+        $this->assertSame("refresh_token_xyz", $token->refreshToken);
+        $this->assertSame("req_abc123", $token->requestId);
+    }
+
+    public function test_create_token_with_basic_prefix_and_no_optional_args(): void
+    {
+        $responseBody = [
+            "access_token" => "secret_token",
+            "token_type" => "bearer",
+            "bot_id" => "bot_123",
+            "workspace_id" => "ws_123",
+            "owner" => [
+                "type" => "workspace",
+                "workspace" => true,
+            ],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], (string) json_encode($responseBody)),
+        ]);
+        $client = $this->createNotionClient($mock, "Basic custom_auth_string");
+
+        $token = $client->authentication()->createToken("code_only");
+
+        $request = $mock->getLastRequest();
+        $this->assertNotNull($request);
+        $this->assertSame("Basic custom_auth_string", $request->getHeaderLine("Authorization"));
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getBody(), true);
+        $this->assertSame("authorization_code", $payload["grant_type"]);
+        $this->assertSame("code_only", $payload["code"]);
+        $this->assertArrayNotHasKey("redirect_uri", $payload);
+        $this->assertArrayNotHasKey("external_account", $payload);
+
+        $this->assertSame("secret_token", $token->accessToken);
+        $this->assertTrue($token->owner->isWorkspace());
+    }
+
+    public function test_refresh_token(): void
+    {
+        $responseBody = [
+            "access_token" => "secret_refreshed_token",
+            "token_type" => "bearer",
+            "bot_id" => "bot_123",
+            "workspace_id" => "ws_123",
+            "owner" => [
+                "type" => "workspace",
+                "workspace" => true,
+            ],
+            "refresh_token" => "new_refresh_token",
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], (string) json_encode($responseBody)),
+        ]);
+        $client = $this->createNotionClient($mock, "client_id:client_secret");
+
+        $token = $client->authentication()->refreshToken("old_refresh_token");
+
+        $request = $mock->getLastRequest();
+        $this->assertNotNull($request);
+        $this->assertSame("POST", $request->getMethod());
+        $this->assertSame("https://api.notion.com/v1/oauth/token", (string) $request->getUri());
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getBody(), true);
+        $this->assertSame("refresh_token", $payload["grant_type"]);
+        $this->assertSame("old_refresh_token", $payload["refresh_token"]);
+
+        $this->assertSame("secret_refreshed_token", $token->accessToken);
+        $this->assertSame("new_refresh_token", $token->refreshToken);
+    }
+
+    public function test_introspect_token(): void
+    {
+        $responseBody = [
+            "active" => true,
+            "scope" => "read:users",
+            "iat" => 1710000000,
+            "request_id" => "req_introspect",
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], (string) json_encode($responseBody)),
+        ]);
+        $client = $this->createNotionClient($mock, "client_id:client_secret");
+
+        $introspection = $client->authentication()->introspectToken("token_to_check");
+
+        $request = $mock->getLastRequest();
+        $this->assertNotNull($request);
+        $this->assertSame("POST", $request->getMethod());
+        $this->assertSame("https://api.notion.com/v1/oauth/introspect", (string) $request->getUri());
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getBody(), true);
+        $this->assertSame(["token" => "token_to_check"], $payload);
+
+        $this->assertTrue($introspection->isActive());
+        $this->assertSame("read:users", $introspection->scope);
+        $this->assertSame(1710000000, $introspection->iat);
+        $this->assertSame("req_introspect", $introspection->requestId);
+    }
+
+    public function test_revoke_token(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, [], "{}"),
+        ]);
+        $client = $this->createNotionClient($mock, "client_id:client_secret");
+
+        $client->authentication()->revokeToken("token_to_revoke");
+
+        $request = $mock->getLastRequest();
+        $this->assertNotNull($request);
+        $this->assertSame("POST", $request->getMethod());
+        $this->assertSame("https://api.notion.com/v1/oauth/revoke", (string) $request->getUri());
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $request->getBody(), true);
+        $this->assertSame(["token" => "token_to_revoke"], $payload);
+    }
+
+    private function createNotionClient(MockHandler $mock, string $token): Notion
+    {
+        $guzzle = new GuzzleClient(["handler" => HandlerStack::create($mock)]);
+        $factory = new HttpFactory();
+        $config = Configuration::createFromPsrImplementations($token, $guzzle, $factory);
+
+        return Notion::createFromConfig($config);
+    }
+}

--- a/tests/Unit/Authentication/ClientTest.php
+++ b/tests/Unit/Authentication/ClientTest.php
@@ -39,10 +39,10 @@ class ClientTest extends TestCase
         $mock = new MockHandler([
             new Response(200, [], (string) json_encode($responseBody)),
         ]);
-        $client = $this->createNotionClient($mock, "my_client_id:my_client_secret");
+        $client = $this->createNotionClient($mock);
 
         $externalAccount = ExternalAccount::create("ext_key", "Ext Name");
-        $token = $client->authentication()->createToken(
+        $token = $client->authentication("my_client_id", "my_client_secret")->createToken(
             code: "auth_code_123",
             redirectUri: "https://example.com/callback",
             externalAccount: $externalAccount,
@@ -75,7 +75,7 @@ class ClientTest extends TestCase
         $this->assertSame("req_abc123", $token->requestId);
     }
 
-    public function test_create_token_with_basic_prefix_and_no_optional_args(): void
+    public function test_create_token_minimal(): void
     {
         $responseBody = [
             "access_token" => "secret_token",
@@ -91,13 +91,15 @@ class ClientTest extends TestCase
         $mock = new MockHandler([
             new Response(200, [], (string) json_encode($responseBody)),
         ]);
-        $client = $this->createNotionClient($mock, "Basic custom_auth_string");
+        $client = $this->createNotionClient($mock);
 
-        $token = $client->authentication()->createToken("code_only");
+        $token = $client->authentication("client_id_val", "client_secret_val")
+            ->createToken("code_only");
 
         $request = $mock->getLastRequest();
         $this->assertNotNull($request);
-        $this->assertSame("Basic custom_auth_string", $request->getHeaderLine("Authorization"));
+        $expectedAuth = "Basic " . base64_encode("client_id_val:client_secret_val");
+        $this->assertSame($expectedAuth, $request->getHeaderLine("Authorization"));
 
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string) $request->getBody(), true);
@@ -127,14 +129,17 @@ class ClientTest extends TestCase
         $mock = new MockHandler([
             new Response(200, [], (string) json_encode($responseBody)),
         ]);
-        $client = $this->createNotionClient($mock, "client_id:client_secret");
+        $client = $this->createNotionClient($mock);
 
-        $token = $client->authentication()->refreshToken("old_refresh_token");
+        $token = $client->authentication("my_client_id", "my_client_secret")
+            ->refreshToken("old_refresh_token");
 
         $request = $mock->getLastRequest();
         $this->assertNotNull($request);
         $this->assertSame("POST", $request->getMethod());
         $this->assertSame("https://api.notion.com/v1/oauth/token", (string) $request->getUri());
+        $expectedAuth = "Basic " . base64_encode("my_client_id:my_client_secret");
+        $this->assertSame($expectedAuth, $request->getHeaderLine("Authorization"));
 
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string) $request->getBody(), true);
@@ -157,14 +162,17 @@ class ClientTest extends TestCase
         $mock = new MockHandler([
             new Response(200, [], (string) json_encode($responseBody)),
         ]);
-        $client = $this->createNotionClient($mock, "client_id:client_secret");
+        $client = $this->createNotionClient($mock);
 
-        $introspection = $client->authentication()->introspectToken("token_to_check");
+        $introspection = $client->authentication("my_client_id", "my_client_secret")
+            ->introspectToken("token_to_check");
 
         $request = $mock->getLastRequest();
         $this->assertNotNull($request);
         $this->assertSame("POST", $request->getMethod());
         $this->assertSame("https://api.notion.com/v1/oauth/introspect", (string) $request->getUri());
+        $expectedAuth = "Basic " . base64_encode("my_client_id:my_client_secret");
+        $this->assertSame($expectedAuth, $request->getHeaderLine("Authorization"));
 
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string) $request->getBody(), true);
@@ -181,21 +189,24 @@ class ClientTest extends TestCase
         $mock = new MockHandler([
             new Response(200, [], "{}"),
         ]);
-        $client = $this->createNotionClient($mock, "client_id:client_secret");
+        $client = $this->createNotionClient($mock);
 
-        $client->authentication()->revokeToken("token_to_revoke");
+        $client->authentication("my_client_id", "my_client_secret")
+            ->revokeToken("token_to_revoke");
 
         $request = $mock->getLastRequest();
         $this->assertNotNull($request);
         $this->assertSame("POST", $request->getMethod());
         $this->assertSame("https://api.notion.com/v1/oauth/revoke", (string) $request->getUri());
+        $expectedAuth = "Basic " . base64_encode("my_client_id:my_client_secret");
+        $this->assertSame($expectedAuth, $request->getHeaderLine("Authorization"));
 
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string) $request->getBody(), true);
         $this->assertSame(["token" => "token_to_revoke"], $payload);
     }
 
-    private function createNotionClient(MockHandler $mock, string $token): Notion
+    private function createNotionClient(MockHandler $mock, string $token = "test_token"): Notion
     {
         $guzzle = new GuzzleClient(["handler" => HandlerStack::create($mock)]);
         $factory = new HttpFactory();

--- a/tests/Unit/Authentication/ExternalAccountTest.php
+++ b/tests/Unit/Authentication/ExternalAccountTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Notion\Test\Unit\Authentication;
+
+use Notion\Authentication\ExternalAccount;
+use PHPUnit\Framework\TestCase;
+
+class ExternalAccountTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $externalAccount = ExternalAccount::create("account_123", "Acme Corporation");
+
+        $this->assertSame("account_123", $externalAccount->key);
+        $this->assertSame("Acme Corporation", $externalAccount->name);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "key" => "account_456",
+            "name" => "Globex Corp",
+        ];
+
+        $externalAccount = ExternalAccount::fromArray($array);
+
+        $this->assertSame("account_456", $externalAccount->key);
+        $this->assertSame("Globex Corp", $externalAccount->name);
+    }
+
+    public function test_to_array(): void
+    {
+        $externalAccount = ExternalAccount::create("account_789", "Initech");
+
+        $expected = [
+            "key" => "account_789",
+            "name" => "Initech",
+        ];
+
+        $this->assertSame($expected, $externalAccount->toArray());
+    }
+}

--- a/tests/Unit/Authentication/ExternalAccountTest.php
+++ b/tests/Unit/Authentication/ExternalAccountTest.php
@@ -15,19 +15,6 @@ class ExternalAccountTest extends TestCase
         $this->assertSame("Acme Corporation", $externalAccount->name);
     }
 
-    public function test_from_array(): void
-    {
-        $array = [
-            "key" => "account_456",
-            "name" => "Globex Corp",
-        ];
-
-        $externalAccount = ExternalAccount::fromArray($array);
-
-        $this->assertSame("account_456", $externalAccount->key);
-        $this->assertSame("Globex Corp", $externalAccount->name);
-    }
-
     public function test_to_array(): void
     {
         $externalAccount = ExternalAccount::create("account_789", "Initech");

--- a/tests/Unit/Authentication/OwnerTest.php
+++ b/tests/Unit/Authentication/OwnerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Notion\Test\Unit\Authentication;
+
+use Notion\Authentication\Owner;
+use Notion\Authentication\OwnerType;
+use Notion\Users\User;
+use PHPUnit\Framework\TestCase;
+
+class OwnerTest extends TestCase
+{
+    public function test_user_owner(): void
+    {
+        $user = User::create("e2586e30-b3e6-42d7-a50e-e374526d56d7");
+        $owner = Owner::user($user);
+
+        $this->assertTrue($owner->isUser());
+        $this->assertFalse($owner->isWorkspace());
+        $this->assertSame(OwnerType::User, $owner->type);
+        $this->assertSame($user, $owner->user);
+    }
+
+    public function test_workspace_owner(): void
+    {
+        $owner = Owner::workspace();
+
+        $this->assertTrue($owner->isWorkspace());
+        $this->assertFalse($owner->isUser());
+        $this->assertSame(OwnerType::Workspace, $owner->type);
+        $this->assertNull($owner->user);
+    }
+
+    public function test_from_array_user(): void
+    {
+        $array = [
+            "type" => "user",
+            "user" => [
+                "object" => "user",
+                "id" => "e2586e30-b3e6-42d7-a50e-e374526d56d7",
+                "name" => "Jane Doe",
+            ],
+        ];
+
+        $owner = Owner::fromArray($array);
+
+        $this->assertTrue($owner->isUser());
+        $this->assertSame("e2586e30-b3e6-42d7-a50e-e374526d56d7", $owner->user?->id);
+        $this->assertSame("Jane Doe", $owner->user?->name);
+    }
+
+    public function test_from_array_workspace(): void
+    {
+        $array = [
+            "type" => "workspace",
+            "workspace" => true,
+        ];
+
+        $owner = Owner::fromArray($array);
+
+        $this->assertTrue($owner->isWorkspace());
+        $this->assertNull($owner->user);
+    }
+}

--- a/tests/Unit/Authentication/OwnerTest.php
+++ b/tests/Unit/Authentication/OwnerTest.php
@@ -9,27 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class OwnerTest extends TestCase
 {
-    public function test_user_owner(): void
-    {
-        $user = User::create("e2586e30-b3e6-42d7-a50e-e374526d56d7");
-        $owner = Owner::user($user);
-
-        $this->assertTrue($owner->isUser());
-        $this->assertFalse($owner->isWorkspace());
-        $this->assertSame(OwnerType::User, $owner->type);
-        $this->assertSame($user, $owner->user);
-    }
-
-    public function test_workspace_owner(): void
-    {
-        $owner = Owner::workspace();
-
-        $this->assertTrue($owner->isWorkspace());
-        $this->assertFalse($owner->isUser());
-        $this->assertSame(OwnerType::Workspace, $owner->type);
-        $this->assertNull($owner->user);
-    }
-
     public function test_from_array_user(): void
     {
         $array = [

--- a/tests/Unit/Authentication/TokenIntrospectionTest.php
+++ b/tests/Unit/Authentication/TokenIntrospectionTest.php
@@ -19,7 +19,6 @@ class TokenIntrospectionTest extends TestCase
         $introspection = TokenIntrospection::fromArray($array);
 
         $this->assertTrue($introspection->active);
-        $this->assertTrue($introspection->isActive());
         $this->assertSame("read:users,write:pages", $introspection->scope);
         $this->assertSame(1710000000, $introspection->iat);
         $this->assertSame("req_introspect_123", $introspection->requestId);
@@ -34,18 +33,8 @@ class TokenIntrospectionTest extends TestCase
         $introspection = TokenIntrospection::fromArray($array);
 
         $this->assertFalse($introspection->active);
-        $this->assertFalse($introspection->isActive());
         $this->assertNull($introspection->scope);
         $this->assertNull($introspection->iat);
         $this->assertNull($introspection->requestId);
-    }
-
-    public function test_create(): void
-    {
-        $introspection = TokenIntrospection::create(true, "read:content", 1720000000);
-
-        $this->assertTrue($introspection->isActive());
-        $this->assertSame("read:content", $introspection->scope);
-        $this->assertSame(1720000000, $introspection->iat);
     }
 }

--- a/tests/Unit/Authentication/TokenIntrospectionTest.php
+++ b/tests/Unit/Authentication/TokenIntrospectionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Notion\Test\Unit\Authentication;
+
+use Notion\Authentication\TokenIntrospection;
+use PHPUnit\Framework\TestCase;
+
+class TokenIntrospectionTest extends TestCase
+{
+    public function test_from_array_active(): void
+    {
+        $array = [
+            "active" => true,
+            "scope" => "read:users,write:pages",
+            "iat" => 1710000000,
+            "request_id" => "req_introspect_123",
+        ];
+
+        $introspection = TokenIntrospection::fromArray($array);
+
+        $this->assertTrue($introspection->active);
+        $this->assertTrue($introspection->isActive());
+        $this->assertSame("read:users,write:pages", $introspection->scope);
+        $this->assertSame(1710000000, $introspection->iat);
+        $this->assertSame("req_introspect_123", $introspection->requestId);
+    }
+
+    public function test_from_array_inactive(): void
+    {
+        $array = [
+            "active" => false,
+        ];
+
+        $introspection = TokenIntrospection::fromArray($array);
+
+        $this->assertFalse($introspection->active);
+        $this->assertFalse($introspection->isActive());
+        $this->assertNull($introspection->scope);
+        $this->assertNull($introspection->iat);
+        $this->assertNull($introspection->requestId);
+    }
+
+    public function test_create(): void
+    {
+        $introspection = TokenIntrospection::create(true, "read:content", 1720000000);
+
+        $this->assertTrue($introspection->isActive());
+        $this->assertSame("read:content", $introspection->scope);
+        $this->assertSame(1720000000, $introspection->iat);
+    }
+}

--- a/tests/Unit/Authentication/TokenResponseTest.php
+++ b/tests/Unit/Authentication/TokenResponseTest.php
@@ -70,46 +70,31 @@ class TokenResponseTest extends TestCase
         $this->assertNull($tokenResponse->requestId);
     }
 
-    public function test_create(): void
-    {
-        $user = User::create("user_123");
-        $owner = Owner::user($user);
-
-        $tokenResponse = TokenResponse::create(
-            accessToken: "secret_custom",
-            botId: "bot_123",
-            workspaceId: "ws_123",
-            owner: $owner,
-            tokenType: "bearer",
-            workspaceName: "My Workspace",
-        );
-
-        $this->assertSame("secret_custom", $tokenResponse->accessToken);
-        $this->assertSame("bot_123", $tokenResponse->botId);
-        $this->assertSame("ws_123", $tokenResponse->workspaceId);
-        $this->assertSame("My Workspace", $tokenResponse->workspaceName);
-        $this->assertTrue($tokenResponse->owner->isUser());
-    }
-
     public function test_multiple_installations_in_same_workspace(): void
     {
         $user1 = User::create("user_1");
         $user2 = User::create("user_2");
         $workspaceId = "shared-workspace-id";
 
-        $installation1 = TokenResponse::create(
-            accessToken: "token_user_1",
-            botId: "bot_user_1",
-            workspaceId: $workspaceId,
-            owner: Owner::user($user1),
-        );
+        $installation1 = TokenResponse::fromArray([
+            "access_token" => "token_user_1",
+            "bot_id" => "bot_user_1",
+            "workspace_id" => $workspaceId,
+            "owner" => [
+                "type" => "user",
+                "user" => $user1->toArray(),
+            ],
+        ]);
 
-        $installation2 = TokenResponse::create(
-            accessToken: "token_user_2",
-            botId: "bot_user_2",
-            workspaceId: $workspaceId,
-            owner: Owner::user($user2),
-        );
+        $installation2 = TokenResponse::fromArray([
+            "access_token" => "token_user_2",
+            "bot_id" => "bot_user_2",
+            "workspace_id" => $workspaceId,
+            "owner" => [
+                "type" => "user",
+                "user" => $user2->toArray(),
+            ],
+        ]);
 
         $this->assertSame($installation1->workspaceId, $installation2->workspaceId);
         $this->assertNotSame($installation1->botId, $installation2->botId);

--- a/tests/Unit/Authentication/TokenResponseTest.php
+++ b/tests/Unit/Authentication/TokenResponseTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Notion\Test\Unit\Authentication;
+
+use Notion\Authentication\Owner;
+use Notion\Authentication\TokenResponse;
+use Notion\Users\User;
+use PHPUnit\Framework\TestCase;
+
+class TokenResponseTest extends TestCase
+{
+    public function test_from_array_with_user_owner(): void
+    {
+        $array = [
+            "access_token" => "secret_token_123",
+            "token_type" => "bearer",
+            "bot_id" => "936998cb-aa55-46ff-b633-875c74239845",
+            "workspace_id" => "787c805a-e7c6-48a6-9be8-1647895188f6",
+            "workspace_name" => "Acme Workspace",
+            "workspace_icon" => "https://example.com/icon.png",
+            "owner" => [
+                "type" => "user",
+                "user" => [
+                    "object" => "user",
+                    "id" => "123e4567-e89b-12d3-a456-426614174000",
+                    "name" => "Jane Doe",
+                ],
+            ],
+            "duplicated_template_id" => "550e8400-e29b-41d4-a716-446655440000",
+            "refresh_token" => "refresh_token_abc",
+            "request_id" => "req_789",
+        ];
+
+        $tokenResponse = TokenResponse::fromArray($array);
+
+        $this->assertSame("secret_token_123", $tokenResponse->accessToken);
+        $this->assertSame("bearer", $tokenResponse->tokenType);
+        $this->assertSame("936998cb-aa55-46ff-b633-875c74239845", $tokenResponse->botId);
+        $this->assertSame("787c805a-e7c6-48a6-9be8-1647895188f6", $tokenResponse->workspaceId);
+        $this->assertSame("Acme Workspace", $tokenResponse->workspaceName);
+        $this->assertSame("https://example.com/icon.png", $tokenResponse->workspaceIcon);
+        $this->assertTrue($tokenResponse->owner->isUser());
+        $this->assertSame("Jane Doe", $tokenResponse->owner->user?->name);
+        $this->assertSame("550e8400-e29b-41d4-a716-446655440000", $tokenResponse->duplicatedTemplateId);
+        $this->assertSame("refresh_token_abc", $tokenResponse->refreshToken);
+        $this->assertSame("req_789", $tokenResponse->requestId);
+    }
+
+    public function test_from_array_with_workspace_owner(): void
+    {
+        $array = [
+            "access_token" => "secret_token_456",
+            "bot_id" => "bot_456",
+            "workspace_id" => "workspace_789",
+            "owner" => [
+                "type" => "workspace",
+                "workspace" => true,
+            ],
+        ];
+
+        $tokenResponse = TokenResponse::fromArray($array);
+
+        $this->assertSame("secret_token_456", $tokenResponse->accessToken);
+        $this->assertSame("bearer", $tokenResponse->tokenType);
+        $this->assertTrue($tokenResponse->owner->isWorkspace());
+        $this->assertNull($tokenResponse->workspaceName);
+        $this->assertNull($tokenResponse->workspaceIcon);
+        $this->assertNull($tokenResponse->duplicatedTemplateId);
+        $this->assertNull($tokenResponse->refreshToken);
+        $this->assertNull($tokenResponse->requestId);
+    }
+
+    public function test_create(): void
+    {
+        $user = User::create("user_123");
+        $owner = Owner::user($user);
+
+        $tokenResponse = TokenResponse::create(
+            accessToken: "secret_custom",
+            botId: "bot_123",
+            workspaceId: "ws_123",
+            owner: $owner,
+            tokenType: "bearer",
+            workspaceName: "My Workspace",
+        );
+
+        $this->assertSame("secret_custom", $tokenResponse->accessToken);
+        $this->assertSame("bot_123", $tokenResponse->botId);
+        $this->assertSame("ws_123", $tokenResponse->workspaceId);
+        $this->assertSame("My Workspace", $tokenResponse->workspaceName);
+        $this->assertTrue($tokenResponse->owner->isUser());
+    }
+
+    public function test_multiple_installations_in_same_workspace(): void
+    {
+        $user1 = User::create("user_1");
+        $user2 = User::create("user_2");
+        $workspaceId = "shared-workspace-id";
+
+        $installation1 = TokenResponse::create(
+            accessToken: "token_user_1",
+            botId: "bot_user_1",
+            workspaceId: $workspaceId,
+            owner: Owner::user($user1),
+        );
+
+        $installation2 = TokenResponse::create(
+            accessToken: "token_user_2",
+            botId: "bot_user_2",
+            workspaceId: $workspaceId,
+            owner: Owner::user($user2),
+        );
+
+        $this->assertSame($installation1->workspaceId, $installation2->workspaceId);
+        $this->assertNotSame($installation1->botId, $installation2->botId);
+        $this->assertNotSame($installation1->accessToken, $installation2->accessToken);
+        $this->assertNotSame($installation1->owner->user?->id, $installation2->owner->user?->id);
+    }
+}

--- a/tests/Unit/Infrastructure/HttpTest.php
+++ b/tests/Unit/Infrastructure/HttpTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response;
 use Notion\Configuration;
 use Notion\Exceptions\ConflictException;
+use Notion\Infrastructure\Http;
 use Notion\Notion;
 use Notion\Pages\Page;
 use Notion\Pages\PageParent;
@@ -16,6 +17,40 @@ use PHPUnit\Framework\TestCase;
 
 final class HttpTest extends TestCase
 {
+    public function test_create_request(): void
+    {
+        $client = new Client();
+        $factory = new HttpFactory();
+        $config = Configuration::createFromPsrImplementations("secret_123", $client, $factory);
+
+        $request = Http::createRequest("https://api.notion.com/v1/users", $config);
+
+        $this->assertSame("GET", $request->getMethod());
+        $this->assertSame("https://api.notion.com/v1/users", (string) $request->getUri());
+        $this->assertSame("Bearer secret_123", $request->getHeaderLine("Authorization"));
+        $this->assertSame($config->version, $request->getHeaderLine("Notion-Version"));
+    }
+
+    public function test_create_auth_request(): void
+    {
+        $client = new Client();
+        $factory = new HttpFactory();
+        $config = Configuration::createFromPsrImplementations("secret_123", $client, $factory);
+
+        $request = Http::createAuthRequest(
+            "https://api.notion.com/v1/oauth/token",
+            $config,
+            "client_id_123",
+            "client_secret_456",
+        );
+
+        $this->assertSame("GET", $request->getMethod());
+        $this->assertSame("https://api.notion.com/v1/oauth/token", (string) $request->getUri());
+        $expectedAuth = "Basic " . base64_encode("client_id_123:client_secret_456");
+        $this->assertSame($expectedAuth, $request->getHeaderLine("Authorization"));
+        $this->assertSame($config->version, $request->getHeaderLine("Notion-Version"));
+    }
+
     public function test_retry_sending_request_after_conflict_errors(): void
     {
         $mock = new MockHandler([

--- a/tests/Unit/NotionTest.php
+++ b/tests/Unit/NotionTest.php
@@ -27,10 +27,13 @@ class NotionTest extends TestCase
     public function test_authentication(): void
     {
         $notion = Notion::create("secret_token");
+        $authClient = $notion->authentication("client_id", "client_secret");
 
         $this->assertInstanceOf(
             \Notion\Authentication\Client::class,
-            $notion->authentication(),
+            $authClient,
         );
+        $this->assertSame("client_id", $authClient->clientId);
+        $this->assertSame("client_secret", $authClient->clientSecret);
     }
 }

--- a/tests/Unit/NotionTest.php
+++ b/tests/Unit/NotionTest.php
@@ -23,4 +23,14 @@ class NotionTest extends TestCase
 
         $this->assertInstanceOf(Notion::class, $notion);
     }
+
+    public function test_authentication(): void
+    {
+        $notion = Notion::create("secret_token");
+
+        $this->assertInstanceOf(
+            \Notion\Authentication\Client::class,
+            $notion->authentication(),
+        );
+    }
 }


### PR DESCRIPTION
Closes #443

## Summary
Add typed `Authentication` client and models to support public OAuth integrations:
- Add `Notion\Authentication\Client` accessible via `$notion->authentication()` with `createToken()`, `refreshToken()`, `introspectToken()`, and `revokeToken()` methods.
- Add `TokenResponse` representing the full OAuth token response with user-level or workspace-level ownership, treating `bot_id` as the unique authorization identifier to support multiple installations in the same workspace.
- Add `Owner` and `OwnerType` representing ownership metadata.
- Add `ExternalAccount` supporting external account metadata on `createToken()`.
- Add `TokenIntrospection` representing token active status and metadata from `/v1/oauth/introspect`.
- Add integration tests and unit tests.
- Update `CHANGELOG.md`.