### PR TITLE
feat: support audio blocks (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support audio blocks (#444).
+  - Add `Notion\Blocks\Audio` block class for creating, parsing, serializing, and updating audio blocks and captions.
+  - Add `BlockType::Audio` to `Notion\Blocks\BlockType` enum.
+  - Add audio block deserialization support to `Notion\Blocks\BlockFactory`.
+  - Add `Notion\Blocks\Renderer\Markdown\AudioRenderer` to render audio blocks to Markdown.
 - Add typed `Authentication` client and models for public OAuth integrations (#443).
 - Add `Notion\DataSources\Query\RelativeDate` enum for relative date filter conditions (#199).
   - Supported relative dates: `Today`, `Tomorrow`, `Yesterday`, `OneWeekAgo`, `OneWeekFromNow`, `OneMonthAgo`, and `OneMonthFromNow`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support audio blocks (#444).
-  - Add `Notion\Blocks\Audio` block class for creating, parsing, serializing, and updating audio blocks and captions.
-  - Add `BlockType::Audio` to `Notion\Blocks\BlockType` enum.
-  - Add audio block deserialization support to `Notion\Blocks\BlockFactory`.
-  - Add `Notion\Blocks\Renderer\Markdown\AudioRenderer` to render audio blocks to Markdown.
 - Add typed `Authentication` client and models for public OAuth integrations (#443).
 - Add `Notion\DataSources\Query\RelativeDate` enum for relative date filter conditions (#199).
   - Supported relative dates: `Today`, `Tomorrow`, `Yesterday`, `OneWeekAgo`, `OneWeekFromNow`, `OneMonthAgo`, and `OneMonthFromNow`.

--- a/docs/blocks/Audio.md
+++ b/docs/blocks/Audio.md
@@ -1,0 +1,31 @@
+# Audio
+
+Embed an audio file.
+
+## Create from a link
+
+```php
+$file = File::createExternal("https://example.com/podcast.mp3");
+$block = Audio::fromFile($file);
+
+// Or create directly from URL:
+$block = Audio::fromUrl("https://example.com/podcast.mp3");
+```
+
+## Change file
+
+```php
+$file = File::createExternal("https://example.com/podcast1.mp3");
+$block = Audio::fromFile($file);
+
+// Add to a Notion page...
+
+$newFile = File::createExternal("https://example.com/podcast2.mp3");
+$block = $block->changeFile($newFile);
+```
+
+## Change caption
+
+```php
+$block = $block->changeCaption(RichText::fromString("Episode 1: Introduction"));
+```

--- a/docs/blocks/index.md
+++ b/docs/blocks/index.md
@@ -45,6 +45,7 @@ $p = $p->changeChildren();
 
 | Block                                  | Support children |
 |----------------------------------------|:----------------:|
+| [Audio](./Audio.md)                     | ❌              |
 | [Bookmark](./Bookmark)                 | ❌              |
 | [Breadcrumb](./Breadcrumb)             | ❌              |
 | [BulletedListItem](./BulletedListItem) | ✔               |

--- a/src/Blocks/Audio.php
+++ b/src/Blocks/Audio.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Notion\Blocks;
+
+use Notion\Common\File;
+use Notion\Common\RichText;
+use Notion\Exceptions\BlockException;
+
+/**
+ * @psalm-import-type BlockMetadataJson from BlockMetadata
+ * @psalm-import-type FileJson from \Notion\Common\File
+ *
+ * @psalm-type AudioJson = array{ audio: FileJson }
+ *
+ * @psalm-immutable
+ */
+final readonly class Audio implements BlockInterface
+{
+    private function __construct(
+        private BlockMetadata $metadata,
+        public File $file,
+    ) {
+        $metadata->checkType(BlockType::Audio);
+    }
+
+    public static function fromFile(File $file): self
+    {
+        $block = BlockMetadata::create(BlockType::Audio);
+
+        return new self($block, $file);
+    }
+
+    public static function fromUrl(string $url): self
+    {
+        $file = File::createExternal($url);
+
+        return self::fromFile($file);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var BlockMetadataJson $array */
+        $block = BlockMetadata::fromArray($array);
+
+        /** @psalm-var AudioJson $array */
+        $file = File::fromArray($array["audio"]);
+
+        return new self($block, $file);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+
+        $array["audio"] = $this->file->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): BlockMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function changeFile(File $file): self
+    {
+        return new self($this->metadata, $file);
+    }
+
+    public function changeUrl(string $url): self
+    {
+        return new self($this->metadata, $this->file->changeUrl($url));
+    }
+
+    public function changeCaption(RichText ...$caption): self
+    {
+        return new self($this->metadata, $this->file->changeCaption(...$caption));
+    }
+
+    public function addChild(BlockInterface $child): never
+    {
+        throw BlockException::noChindrenSupport();
+    }
+
+    public function changeChildren(BlockInterface ...$children): never
+    {
+        throw BlockException::noChindrenSupport();
+    }
+
+    public function delete(): BlockInterface
+    {
+        return new self(
+            $this->metadata->delete(),
+            $this->file,
+        );
+    }
+
+    /**
+     * @deprecated 1.17.0 Use `delete()` instead.
+     * @codeCoverageIgnore
+     */
+    public function archive(): BlockInterface
+    {
+        return $this->delete();
+    }
+}

--- a/src/Blocks/BlockFactory.php
+++ b/src/Blocks/BlockFactory.php
@@ -12,6 +12,7 @@ final readonly class BlockFactory
         $type = $array["type"];
 
         return match ($type) {
+            BlockType::Audio->value            => Audio::fromArray($array),
             BlockType::Bookmark->value         => Bookmark::fromArray($array),
             BlockType::Breadcrumb->value       => Breadcrumb::fromArray($array),
             BlockType::BulletedListItem->value => BulletedListItem::fromArray($array),

--- a/src/Blocks/BlockType.php
+++ b/src/Blocks/BlockType.php
@@ -20,6 +20,7 @@ enum BlockType: string
     case Embed = "embed";
     case Image = "image";
     case Video = "video";
+    case Audio = "audio";
     case File = "file";
     case Pdf = "pdf";
     case Bookmark = "bookmark";

--- a/src/Blocks/Renderer/Markdown/AudioRenderer.php
+++ b/src/Blocks/Renderer/Markdown/AudioRenderer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Notion\Blocks\Renderer\Markdown;
+
+use Notion\Blocks\Audio;
+use Notion\Blocks\BlockInterface;
+use Notion\Blocks\Renderer\BlockRendererInterface;
+use Notion\Blocks\Renderer\MarkdownRenderer;
+
+final readonly class AudioRenderer implements BlockRendererInterface
+{
+    public static function render(BlockInterface $block, int $depth = 0): string
+    {
+        if (!$block instanceof Audio) {
+            return "";
+        }
+
+        if ($block->file->url === null) {
+            return "";
+        }
+
+        return MarkdownRenderer::ident($block->file->url, $depth);
+    }
+}

--- a/src/Blocks/Renderer/MarkdownRenderer.php
+++ b/src/Blocks/Renderer/MarkdownRenderer.php
@@ -58,6 +58,7 @@ final readonly class MarkdownRenderer implements RendererInterface
         }
 
         return match ($block->metadata()->type) {
+            BlockType::Audio            => Markdown\AudioRenderer::render($block, $depth),
             BlockType::Bookmark         => Markdown\BookmarkRenderer::render($block, $depth),
             BlockType::Breadcrumb       => Markdown\BreadcrumbRenderer::render($block, $depth),
             BlockType::BulletedListItem => Markdown\BulletedListItemRenderer::render($block, $depth),

--- a/tests/Integration/BlocksTest.php
+++ b/tests/Integration/BlocksTest.php
@@ -2,6 +2,7 @@
 
 namespace Notion\Test\Integration;
 
+use Notion\Blocks\Audio;
 use Notion\Blocks\BlockType;
 use Notion\Blocks\Bookmark;
 use Notion\Blocks\Breadcrumb;
@@ -57,6 +58,7 @@ class BlocksTest extends TestCase
             ToDo::fromString("To do item"),
             Toggle::fromString("Toggle"),
             // TODO: Video
+            // TODO: Audio
             ColumnList::create(
                 Column::create(Paragraph::fromString("Paragraph")),
                 Column::create(Paragraph::fromString("Paragraph")),
@@ -156,6 +158,21 @@ class BlocksTest extends TestCase
         }
 
         $this->assertSame(BlockType::Paragraph, $blocks[0]->metadata()->type);
+    }
+
+    public function test_add_audio_block(): void
+    {
+        $client = Helper::client();
+
+        $blocks = $client->blocks()->append(Helper::testPageId(), [
+            Audio::fromUrl("https://example.com/audio.mp3"),
+        ]);
+
+        foreach ($blocks as $block) {
+            $client->blocks()->delete($block->metadata()->id);
+        }
+
+        $this->assertSame(BlockType::Audio, $blocks[0]->metadata()->type);
     }
 
     public function test_add_to_inexistent_block(): void

--- a/tests/Unit/Blocks/AudioTest.php
+++ b/tests/Unit/Blocks/AudioTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Notion\Test\Unit\Blocks;
+
+use Notion\Blocks\Audio;
+use Notion\Blocks\BlockFactory;
+use Notion\Blocks\Paragraph;
+use Notion\Common\Date;
+use Notion\Common\File;
+use Notion\Common\RichText;
+use Notion\Exceptions\BlockException;
+use PHPUnit\Framework\TestCase;
+
+class AudioTest extends TestCase
+{
+    public function test_create_audio(): void
+    {
+        $file = File::createExternal("https://my-site.com/audio.mp3");
+        $audio = Audio::fromFile($file);
+
+        $this->assertEquals($file, $audio->file);
+    }
+
+    public function test_create_from_url(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio.mp3");
+
+        $this->assertEquals("https://my-site.com/audio.mp3", $audio->file->url);
+        $this->assertTrue($audio->file->isExternal());
+    }
+
+    public function test_create_from_array(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "04a13895-f072-4814-8af7-cd11af127040",
+            "created_time"     => "2021-10-18T17:09:00.000Z",
+            "last_edited_time" => "2021-10-18T17:09:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "audio",
+            "audio"            => [
+                "type"     => "external",
+                "external" => [
+                    "url" => "https://my-site.com/audio.mp3",
+                ],
+            ],
+        ];
+
+        $audio = Audio::fromArray($array);
+
+        $this->assertEquals("https://my-site.com/audio.mp3", $audio->file->url);
+        $this->assertEquals($audio, BlockFactory::fromArray($array));
+    }
+
+    public function test_create_from_array_with_caption(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "04a13895-f072-4814-8af7-cd11af127040",
+            "created_time"     => "2021-10-18T17:09:00.000Z",
+            "last_edited_time" => "2021-10-18T17:09:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "audio",
+            "audio"            => [
+                "type"     => "external",
+                "external" => [
+                    "url" => "https://my-site.com/audio.mp3",
+                ],
+                "caption" => [
+                    [
+                        "type"        => "text",
+                        "text"        => [ "content" => "Podcast episode 1", "link" => null ],
+                        "annotations" => [
+                            "bold"          => false,
+                            "italic"        => false,
+                            "strikethrough" => false,
+                            "underline"     => false,
+                            "code"          => false,
+                            "color"         => "default",
+                        ],
+                        "plain_text"  => "Podcast episode 1",
+                        "href"        => null,
+                    ],
+                ],
+            ],
+        ];
+
+        $audio = Audio::fromArray($array);
+
+        $this->assertEquals("Podcast episode 1", $audio->file->caption[0]->plainText);
+        $this->assertEquals($audio, BlockFactory::fromArray($array));
+    }
+
+    public function test_error_on_wrong_type(): void
+    {
+        $this->expectException(BlockException::class);
+        $array = [
+            "object"           => "block",
+            "id"               => "04a13895-f072-4814-8af7-cd11af127040",
+            "created_time"     => "2021-10-18T17:09:00.000Z",
+            "last_edited_time" => "2021-10-18T17:09:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "wrong-type",
+            "audio"            => [
+                "type"     => "external",
+                "external" => [
+                    "url" => "https://my-site.com/audio.mp3",
+                ],
+            ],
+        ];
+
+        Audio::fromArray($array);
+    }
+
+    public function test_transform_in_array(): void
+    {
+        $file = File::createExternal("https://my-site.com/audio.mp3");
+        $audio = Audio::fromFile($file);
+
+        $expected = [
+            "object"           => "block",
+            "created_time"     => $audio->metadata()->createdTime->format(Date::FORMAT),
+            "last_edited_time" => $audio->metadata()->createdTime->format(Date::FORMAT),
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "audio",
+            "audio"            => [
+                "type"     => "external",
+                "external" => [
+                    "url" => "https://my-site.com/audio.mp3",
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $audio->toArray());
+    }
+
+    public function test_replace_file(): void
+    {
+        $file1 = File::createExternal("https://my-site.com/audio1.mp3");
+        $file2 = File::createExternal("https://my-site.com/audio2.mp3");
+
+        $old = Audio::fromFile($file1);
+        $new = $old->changeFile($file2);
+
+        $this->assertEquals($file1, $old->file);
+        $this->assertEquals($file2, $new->file);
+    }
+
+    public function test_change_url(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio1.mp3");
+        $new = $audio->changeUrl("https://my-site.com/audio2.mp3");
+
+        $this->assertEquals("https://my-site.com/audio2.mp3", $new->file->url);
+    }
+
+    public function test_change_caption(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio.mp3");
+        $caption = RichText::fromString("Sample caption");
+        $new = $audio->changeCaption($caption);
+
+        $this->assertEquals([$caption], $new->file->caption);
+    }
+
+    public function test_no_children_support(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio.mp3");
+
+        $this->expectException(BlockException::class);
+        /** @psalm-suppress UnusedMethodCall */
+        $audio->changeChildren();
+    }
+
+    public function test_no_children_support_2(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio.mp3");
+
+        $this->expectException(BlockException::class);
+        /** @psalm-suppress UnusedMethodCall */
+        $audio->addChild(Paragraph::create());
+    }
+
+    public function test_delete(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio.mp3");
+        $deleted = $audio->delete();
+
+        $this->assertTrue($deleted->metadata()->inTrash);
+    }
+
+    public function test_archive(): void
+    {
+        $audio = Audio::fromUrl("https://my-site.com/audio.mp3");
+        /** @psalm-suppress DeprecatedMethod */
+        $archived = $audio->archive();
+
+        $this->assertTrue($archived->metadata()->inTrash);
+    }
+}

--- a/tests/Unit/Blocks/Renderer/Markdown/AudioRendererTest.php
+++ b/tests/Unit/Blocks/Renderer/Markdown/AudioRendererTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Notion\Test\Unit\Blocks\Renderer\Markdown;
+
+use Notion\Blocks\Audio;
+use Notion\Blocks\Divider;
+use Notion\Blocks\Renderer\Markdown\AudioRenderer;
+use Notion\Common\File;
+use PHPUnit\Framework\TestCase;
+
+class AudioRendererTest extends TestCase
+{
+    public function test_render(): void
+    {
+        $block = Audio::fromUrl("https://example.com/audio.mp3");
+
+        $markdown = AudioRenderer::render($block);
+
+        $expected = "https://example.com/audio.mp3";
+
+        $this->assertSame($expected, $markdown);
+    }
+
+    public function test_render_null_url(): void
+    {
+        $file = File::createFileUpload("file-upload-id");
+        $block = Audio::fromFile($file);
+
+        $markdown = AudioRenderer::render($block);
+
+        $this->assertSame("", $markdown);
+    }
+
+    public function test_invalid_block(): void
+    {
+        $markdown = AudioRenderer::render(Divider::create());
+
+        $this->assertSame("", $markdown);
+    }
+}


### PR DESCRIPTION
Closes #444

## Summary
Add support for Notion audio blocks:
- Add `Notion\Blocks\Audio` model representing audio blocks with support for internal, external, and file upload sources, along with caption modifications.
- Add `BlockType::Audio` to `Notion\Blocks\BlockType` enum.
- Add audio block deserialization support to `Notion\Blocks\BlockFactory`.
- Add `Notion\Blocks\Renderer\Markdown\AudioRenderer` and register it in `MarkdownRenderer`.
- Add unit tests for `Audio` model and `AudioRenderer`.
- Add integration test for adding audio blocks in `tests/Integration/BlocksTest.php`.
- Add documentation and update `CHANGELOG.md`.