### PR TITLE
feat: support rollup data source properties (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support rollup data source properties (#445).
-  - Add `Notion\DataSources\Properties\Rollup` to represent rollup schema properties.
-  - Add `Notion\DataSources\Properties\RollupFunction` enum with all 22 rollup aggregation functions supported by Notion.
-  - Add `PropertyCollection::getRollup()` and `PropertyCollection::getRollupById()` methods.
-  - Map `rollup` property definitions to `Notion\DataSources\Properties\Rollup` in `PropertyFactory` instead of `Unknown`.
 - Support audio blocks (#444).
 - Add typed `Authentication` client and models for public OAuth integrations (#443).
 - Add `Notion\DataSources\Query\RelativeDate` enum for relative date filter conditions (#199).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support rollup data source properties (#445).
+  - Add `Notion\DataSources\Properties\Rollup` to represent rollup schema properties.
+  - Add `Notion\DataSources\Properties\RollupFunction` enum with all 22 rollup aggregation functions supported by Notion.
+  - Add `PropertyCollection::getRollup()` and `PropertyCollection::getRollupById()` methods.
+  - Map `rollup` property definitions to `Notion\DataSources\Properties\Rollup` in `PropertyFactory` instead of `Unknown`.
 - Support audio blocks (#444).
 - Add typed `Authentication` client and models for public OAuth integrations (#443).
 - Add `Notion\DataSources\Query\RelativeDate` enum for relative date filter conditions (#199).

--- a/src/DataSources/Properties/PropertyCollection.php
+++ b/src/DataSources/Properties/PropertyCollection.php
@@ -221,6 +221,16 @@ final readonly class PropertyCollection
         return $this->getTypedById($propertyId, RichTextProperty::class);
     }
 
+    public function getRollup(string $propertyName): Rollup
+    {
+        return $this->getTyped($propertyName, Rollup::class);
+    }
+
+    public function getRollupById(string $propertyId): Rollup
+    {
+        return $this->getTypedById($propertyId, Rollup::class);
+    }
+
     public function getSelect(string $propertyName): Select
     {
         return $this->getTyped($propertyName, Select::class);

--- a/src/DataSources/Properties/PropertyFactory.php
+++ b/src/DataSources/Properties/PropertyFactory.php
@@ -27,6 +27,7 @@ final readonly class PropertyFactory
             PropertyType::PhoneNumber    => PhoneNumber::fromArray($array),
             PropertyType::Relation       => Relation::fromArray($array),
             PropertyType::RichText       => RichTextProperty::fromArray($array),
+            PropertyType::Rollup         => Rollup::fromArray($array),
             PropertyType::Select         => Select::fromArray($array),
             PropertyType::Status         => Status::fromArray($array),
             PropertyType::Title          => Title::fromArray($array),

--- a/src/DataSources/Properties/Rollup.php
+++ b/src/DataSources/Properties/Rollup.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Notion\DataSources\Properties;
+
+/**
+ * @psalm-type RollupJson = array{
+ *      id: string,
+ *      name: string,
+ *      type: "rollup",
+ *      rollup: array{
+ *          function: string,
+ *          relation_property_name?: string|null,
+ *          relation_property_id?: string|null,
+ *          rollup_property_name?: string|null,
+ *          rollup_property_id?: string|null,
+ *      },
+ *      description?: string,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class Rollup implements PropertyInterface
+{
+    private function __construct(
+        private PropertyMetadata $metadata,
+        public RollupFunction $function,
+        public string|null $relationPropertyName,
+        public string|null $relationPropertyId,
+        public string|null $rollupPropertyName,
+        public string|null $rollupPropertyId,
+    ) {
+    }
+
+    public static function create(
+        string $propertyName,
+        string $relationPropertyName,
+        string $rollupPropertyName,
+        RollupFunction $function = RollupFunction::ShowOriginal,
+    ): self {
+        $metadata = PropertyMetadata::create("", $propertyName, PropertyType::Rollup);
+
+        return new self(
+            $metadata,
+            $function,
+            $relationPropertyName,
+            null,
+            $rollupPropertyName,
+            null,
+        );
+    }
+
+    public static function createById(
+        string $propertyName,
+        string $relationPropertyId,
+        string $rollupPropertyId,
+        RollupFunction $function = RollupFunction::ShowOriginal,
+    ): self {
+        $metadata = PropertyMetadata::create("", $propertyName, PropertyType::Rollup);
+
+        return new self(
+            $metadata,
+            $function,
+            null,
+            $relationPropertyId,
+            null,
+            $rollupPropertyId,
+        );
+    }
+
+    public function metadata(): PropertyMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function changeFunction(RollupFunction $function): self
+    {
+        return new self(
+            $this->metadata,
+            $function,
+            $this->relationPropertyName,
+            $this->relationPropertyId,
+            $this->rollupPropertyName,
+            $this->rollupPropertyId,
+        );
+    }
+
+    public function changeRelationPropertyName(string $relationPropertyName): self
+    {
+        return new self(
+            $this->metadata,
+            $this->function,
+            $relationPropertyName,
+            $this->relationPropertyId,
+            $this->rollupPropertyName,
+            $this->rollupPropertyId,
+        );
+    }
+
+    public function changeRelationPropertyId(string $relationPropertyId): self
+    {
+        return new self(
+            $this->metadata,
+            $this->function,
+            $this->relationPropertyName,
+            $relationPropertyId,
+            $this->rollupPropertyName,
+            $this->rollupPropertyId,
+        );
+    }
+
+    public function changeRollupPropertyName(string $rollupPropertyName): self
+    {
+        return new self(
+            $this->metadata,
+            $this->function,
+            $this->relationPropertyName,
+            $this->relationPropertyId,
+            $rollupPropertyName,
+            $this->rollupPropertyId,
+        );
+    }
+
+    public function changeRollupPropertyId(string $rollupPropertyId): self
+    {
+        return new self(
+            $this->metadata,
+            $this->function,
+            $this->relationPropertyName,
+            $this->relationPropertyId,
+            $this->rollupPropertyName,
+            $rollupPropertyId,
+        );
+    }
+
+    public function changeTargetPropertyName(string $targetPropertyName): self
+    {
+        return $this->changeRollupPropertyName($targetPropertyName);
+    }
+
+    public function changeTargetPropertyId(string $targetPropertyId): self
+    {
+        return $this->changeRollupPropertyId($targetPropertyId);
+    }
+
+    public function targetPropertyName(): string|null
+    {
+        return $this->rollupPropertyName;
+    }
+
+    public function targetPropertyId(): string|null
+    {
+        return $this->rollupPropertyId;
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var RollupJson $array */
+        $metadata = PropertyMetadata::fromArray($array);
+
+        $rollup = $array["rollup"];
+        $function = RollupFunction::from($rollup["function"]);
+        $relationPropertyName = $rollup["relation_property_name"] ?? null;
+        $relationPropertyId = $rollup["relation_property_id"] ?? null;
+        $rollupPropertyName = $rollup["rollup_property_name"] ?? null;
+        $rollupPropertyId = $rollup["rollup_property_id"] ?? null;
+
+        return new self(
+            $metadata,
+            $function,
+            $relationPropertyName,
+            $relationPropertyId,
+            $rollupPropertyName,
+            $rollupPropertyId,
+        );
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+
+        $rollup = [
+            "function" => $this->function->value,
+        ];
+
+        if ($this->relationPropertyName !== null) {
+            $rollup["relation_property_name"] = $this->relationPropertyName;
+        }
+
+        if ($this->relationPropertyId !== null) {
+            $rollup["relation_property_id"] = $this->relationPropertyId;
+        }
+
+        if ($this->rollupPropertyName !== null) {
+            $rollup["rollup_property_name"] = $this->rollupPropertyName;
+        }
+
+        if ($this->rollupPropertyId !== null) {
+            $rollup["rollup_property_id"] = $this->rollupPropertyId;
+        }
+
+        $array["rollup"] = $rollup;
+
+        return $array;
+    }
+}

--- a/src/DataSources/Properties/RollupFunction.php
+++ b/src/DataSources/Properties/RollupFunction.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Notion\DataSources\Properties;
+
+enum RollupFunction: string
+{
+    case Average = "average";
+    case Checked = "checked";
+    case Count = "count";
+    case CountValues = "count_values";
+    case DateRange = "date_range";
+    case EarliestDate = "earliest_date";
+    case Empty = "empty";
+    case LatestDate = "latest_date";
+    case Max = "max";
+    case Median = "median";
+    case Min = "min";
+    case NotEmpty = "not_empty";
+    case PercentChecked = "percent_checked";
+    case PercentEmpty = "percent_empty";
+    case PercentNotEmpty = "percent_not_empty";
+    case PercentUnchecked = "percent_unchecked";
+    case Range = "range";
+    case ShowOriginal = "show_original";
+    case ShowUnique = "show_unique";
+    case Sum = "sum";
+    case Unchecked = "unchecked";
+    case Unique = "unique";
+}

--- a/tests/Integration/DataSourcesTest.php
+++ b/tests/Integration/DataSourcesTest.php
@@ -10,7 +10,10 @@ use Notion\Databases\Database;
 use Notion\Databases\DatabaseParent;
 use Notion\Databases\DatabaseParentType;
 use Notion\DataSources\Properties\Date;
+use Notion\DataSources\Properties\Relation;
 use Notion\DataSources\Properties\RichTextProperty;
+use Notion\DataSources\Properties\Rollup;
+use Notion\DataSources\Properties\RollupFunction;
 use Notion\DataSources\Properties\Select;
 use Notion\DataSources\Properties\SelectOption;
 use Notion\DataSources\Properties\Title;
@@ -65,6 +68,36 @@ class DataSourcesTest extends TestCase
             "Test prop",
             $dataSource->properties()->get("Test prop")->metadata()->name
         );
+
+        $client->databases()->delete($database);
+    }
+
+    public function test_create_and_update_rollup_property(): void
+    {
+        $database = $this->newDatabase();
+        $tasksDataSource = $this->newDataSource($database->id, "Tasks");
+        $client = Helper::client();
+
+        $relation = Relation::createUnidirectional("Tasks", $tasksDataSource->id);
+        $projectsDataSource = DataSource::create(DataSourceParent::database($database->id))
+            ->changeTitle("Projects")
+            ->addProperty($relation);
+        $projectsDataSource = $client->dataSources()->create($projectsDataSource);
+
+        $rollup = Rollup::create(
+            "Total tasks",
+            "Tasks",
+            "Title",
+            RollupFunction::Count,
+        );
+        $projectsDataSource = $projectsDataSource->addProperty($rollup);
+        $projectsDataSource = $client->dataSources()->update($projectsDataSource);
+
+        $retrievedRollup = $projectsDataSource->properties()->getRollup("Total tasks");
+
+        $this->assertEquals("Total tasks", $retrievedRollup->metadata()->name);
+        $this->assertSame(RollupFunction::Count, $retrievedRollup->function);
+        $this->assertEquals("Tasks", $retrievedRollup->relationPropertyName);
 
         $client->databases()->delete($database);
     }

--- a/tests/Unit/DataSources/Properties/PropertyCollectionTest.php
+++ b/tests/Unit/DataSources/Properties/PropertyCollectionTest.php
@@ -229,6 +229,15 @@ class PropertyCollectionTest extends TestCase
         $this->assertSame($p, $c->getRichText("Name"));
     }
 
+    public function test_get_rollup(): void
+    {
+        $p = Properties\Rollup::create("Name", "Tasks", "Title");
+
+        $c = PropertyCollection::create($p);
+
+        $this->assertSame($p, $c->getRollup("Name"));
+    }
+
     public function test_get_select(): void
     {
         $p = Properties\Select::create("Name");
@@ -504,6 +513,24 @@ class PropertyCollectionTest extends TestCase
         $c = PropertyCollection::create($p);
 
         $this->assertSame($p, $c->getRichTextById("abc"));
+    }
+
+    public function test_get_rollup_by_id(): void
+    {
+        $p = Properties\Rollup::fromArray([
+            "id"    => "abc",
+            "name"  => "dummy",
+            "type"  => "rollup",
+            "rollup" => [
+                "function"               => "count",
+                "relation_property_name" => "Tasks",
+                "rollup_property_name"   => "Title",
+            ],
+        ]);
+
+        $c = PropertyCollection::create($p);
+
+        $this->assertSame($p, $c->getRollupById("abc"));
     }
 
     public function test_get_select_by_id(): void

--- a/tests/Unit/DataSources/Properties/RollupTest.php
+++ b/tests/Unit/DataSources/Properties/RollupTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Notion\Test\Unit\DataSources\Properties;
+
+use Notion\DataSources\Properties\PropertyFactory;
+use Notion\DataSources\Properties\PropertyType;
+use Notion\DataSources\Properties\Rollup;
+use Notion\DataSources\Properties\RollupFunction;
+use PHPUnit\Framework\TestCase;
+
+class RollupTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $rollup = Rollup::create(
+            "Estimated total time",
+            "Tasks",
+            "Days to complete",
+        );
+
+        $this->assertSame("Estimated total time", $rollup->metadata()->name);
+        $this->assertSame(PropertyType::Rollup, $rollup->metadata()->type);
+        $this->assertSame(RollupFunction::ShowOriginal, $rollup->function);
+        $this->assertSame("Tasks", $rollup->relationPropertyName);
+        $this->assertSame("Days to complete", $rollup->rollupPropertyName);
+        $this->assertNull($rollup->relationPropertyId);
+        $this->assertNull($rollup->rollupPropertyId);
+    }
+
+    public function test_create_with_function(): void
+    {
+        $rollup = Rollup::create(
+            "Total time",
+            "Tasks",
+            "Days to complete",
+            RollupFunction::Sum,
+        );
+
+        $this->assertSame(RollupFunction::Sum, $rollup->function);
+    }
+
+    public function test_create_by_id(): void
+    {
+        $rollup = Rollup::createById(
+            "Total time",
+            "rel_123",
+            "prop_456",
+            RollupFunction::Count,
+        );
+
+        $this->assertSame("Total time", $rollup->metadata()->name);
+        $this->assertSame(PropertyType::Rollup, $rollup->metadata()->type);
+        $this->assertSame(RollupFunction::Count, $rollup->function);
+        $this->assertSame("rel_123", $rollup->relationPropertyId);
+        $this->assertSame("prop_456", $rollup->rollupPropertyId);
+        $this->assertNull($rollup->relationPropertyName);
+        $this->assertNull($rollup->rollupPropertyName);
+    }
+
+    public function test_change_function(): void
+    {
+        $rollup = Rollup::create("Total time", "Tasks", "Days")
+            ->changeFunction(RollupFunction::Average);
+
+        $this->assertSame(RollupFunction::Average, $rollup->function);
+    }
+
+    public function test_change_relation_property_name(): void
+    {
+        $rollup = Rollup::create("Total time", "Tasks", "Days")
+            ->changeRelationPropertyName("Subtasks");
+
+        $this->assertSame("Subtasks", $rollup->relationPropertyName);
+    }
+
+    public function test_change_relation_property_id(): void
+    {
+        $rollup = Rollup::create("Total time", "Tasks", "Days")
+            ->changeRelationPropertyId("rel_999");
+
+        $this->assertSame("rel_999", $rollup->relationPropertyId);
+    }
+
+    public function test_change_rollup_property_name(): void
+    {
+        $rollup = Rollup::create("Total time", "Tasks", "Days")
+            ->changeRollupPropertyName("Hours");
+
+        $this->assertSame("Hours", $rollup->rollupPropertyName);
+    }
+
+    public function test_change_rollup_property_id(): void
+    {
+        $rollup = Rollup::create("Total time", "Tasks", "Days")
+            ->changeRollupPropertyId("prop_999");
+
+        $this->assertSame("prop_999", $rollup->rollupPropertyId);
+    }
+
+    public function test_target_property_aliases(): void
+    {
+        $rollup = Rollup::create("Total time", "Tasks", "Days")
+            ->changeTargetPropertyName("Hours")
+            ->changeTargetPropertyId("prop_123");
+
+        $this->assertSame("Hours", $rollup->targetPropertyName());
+        $this->assertSame("prop_123", $rollup->targetPropertyId());
+        $this->assertSame("Hours", $rollup->rollupPropertyName);
+        $this->assertSame("prop_123", $rollup->rollupPropertyId);
+    }
+
+    public function test_array_conversion(): void
+    {
+        $array = [
+            "id"    => "%5E%7Cy%3C",
+            "name"  => "Estimated total project time",
+            "type"  => "rollup",
+            "rollup" => [
+                "function"               => "sum",
+                "relation_property_name" => "Tasks",
+                "relation_property_id"   => "Y]<y",
+                "rollup_property_name"   => "Days to complete",
+                "rollup_property_id"     => "\\nyY",
+            ],
+        ];
+
+        $rollup = Rollup::fromArray($array);
+        $fromFactory = PropertyFactory::fromArray($array);
+
+        $this->assertInstanceOf(Rollup::class, $fromFactory);
+        $this->assertSame("Estimated total project time", $rollup->metadata()->name);
+        $this->assertSame(RollupFunction::Sum, $rollup->function);
+        $this->assertSame("Tasks", $rollup->relationPropertyName);
+        $this->assertSame("Y]<y", $rollup->relationPropertyId);
+        $this->assertSame("Days to complete", $rollup->rollupPropertyName);
+        $this->assertSame("\\nyY", $rollup->rollupPropertyId);
+
+        $this->assertEquals($array, $rollup->toArray());
+        $this->assertEquals($array, $fromFactory->toArray());
+    }
+
+    public function test_array_conversion_names_only(): void
+    {
+        $rollup = Rollup::create("Total tasks", "Tasks", "Name", RollupFunction::Count);
+
+        $expected = [
+            "id"   => "",
+            "name" => "Total tasks",
+            "type" => "rollup",
+            "rollup" => [
+                "function"               => "count",
+                "relation_property_name" => "Tasks",
+                "rollup_property_name"   => "Name",
+            ],
+        ];
+
+        $this->assertEquals($expected, $rollup->toArray());
+    }
+
+    public function test_array_conversion_ids_only(): void
+    {
+        $rollup = Rollup::createById("Total tasks", "rel_123", "prop_456", RollupFunction::Count);
+
+        $expected = [
+            "id"   => "",
+            "name" => "Total tasks",
+            "type" => "rollup",
+            "rollup" => [
+                "function"             => "count",
+                "relation_property_id" => "rel_123",
+                "rollup_property_id"   => "prop_456",
+            ],
+        ];
+
+        $this->assertEquals($expected, $rollup->toArray());
+    }
+}


### PR DESCRIPTION
Closes #445

## Summary
Add typed support for rollup schema properties on data sources:
- Add `Notion\DataSources\Properties\Rollup` implementing `PropertyInterface`, representing the relation property, target property, and rollup aggregation function.
- Add `Notion\DataSources\Properties\RollupFunction` enum containing all 22 rollup functions supported by Notion.
- Map `PropertyType::Rollup` to `Rollup::fromArray($array)` in `PropertyFactory` instead of falling back to `Unknown`.
- Add typed getter methods `getRollup()` and `getRollupById()` to `PropertyCollection`.
- Add unit tests in `tests/Unit/DataSources/Properties/RollupTest.php` and `tests/Unit/DataSources/Properties/PropertyCollectionTest.php`.
- Add integration test `test_create_and_update_rollup_property()` in `tests/Integration/DataSourcesTest.php`.
- Document changes in `CHANGELOG.md`.