### PR TITLE
feat: support retrieving individual page properties (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support retrieving individual page properties (#446).
 - Support rollup data source properties (#445).
 - Support audio blocks (#444).
 - Add typed `Authentication` client and models for public OAuth integrations (#443).

--- a/src/DataSources/Properties/RollupFunction.php
+++ b/src/DataSources/Properties/RollupFunction.php
@@ -7,6 +7,7 @@ enum RollupFunction: string
     case Average = "average";
     case Checked = "checked";
     case Count = "count";
+    case CountPerGroup = "count_per_group";
     case CountValues = "count_values";
     case DateRange = "date_range";
     case EarliestDate = "earliest_date";
@@ -19,6 +20,7 @@ enum RollupFunction: string
     case PercentChecked = "percent_checked";
     case PercentEmpty = "percent_empty";
     case PercentNotEmpty = "percent_not_empty";
+    case PercentPerGroup = "percent_per_group";
     case PercentUnchecked = "percent_unchecked";
     case Range = "range";
     case ShowOriginal = "show_original";

--- a/src/Pages/Client.php
+++ b/src/Pages/Client.php
@@ -13,6 +13,9 @@ use Notion\Pages\Properties\LastEditedTime;
 use Notion\Pages\Properties\PropertyInterface;
 use Notion\Pages\Properties\PropertyType;
 use Notion\Pages\Properties\UniqueId;
+use Notion\Pages\PropertyItems\PropertyItemFactory;
+use Notion\Pages\PropertyItems\PropertyItemInterface;
+use Notion\Pages\PropertyItems\PropertyItemList;
 
 /**
  * @psalm-import-type PageJson from Page
@@ -36,6 +39,31 @@ final readonly class Client
         $body = Http::sendRequest($request, $this->config);
 
         return Page::fromArray($body);
+    }
+
+    public function findProperty(
+        string $pageId,
+        string $propertyId,
+        string|null $startCursor = null,
+        int|null $pageSize = null,
+    ): PropertyItemInterface|PropertyItemList {
+        $url = "https://api.notion.com/v1/pages/{$pageId}/properties/{$propertyId}";
+        $queryParams = [];
+        if ($startCursor !== null) {
+            $queryParams["start_cursor"] = $startCursor;
+        }
+        if ($pageSize !== null) {
+            $queryParams["page_size"] = (string) $pageSize;
+        }
+        if (!empty($queryParams)) {
+            $url .= "?" . http_build_query($queryParams);
+        }
+
+        $request = Http::createRequest($url, $this->config);
+        /** @var array<string, mixed> $body */
+        $body = Http::sendRequest($request, $this->config);
+
+        return PropertyItemFactory::fromArray($body);
     }
 
     /** @param list<BlockInterface> $content */

--- a/src/Pages/Properties/FormulaType.php
+++ b/src/Pages/Properties/FormulaType.php
@@ -8,4 +8,5 @@ enum FormulaType: string
     case Number = "number";
     case Boolean = "boolean";
     case Date = "date";
+    case Unsupported = "unsupported";
 }

--- a/src/Pages/PropertyItems/CheckboxPropertyItem.php
+++ b/src/Pages/PropertyItems/CheckboxPropertyItem.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type CheckboxItemJson = array{
+ *      id: string,
+ *      type: "checkbox",
+ *      checkbox: bool,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class CheckboxPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public bool $checkbox,
+    ) {
+    }
+
+    public static function create(bool $checkbox, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Checkbox);
+
+        return new self($metadata, $checkbox);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var CheckboxItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $checkbox = $array["checkbox"];
+
+        return new self($metadata, $checkbox);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["checkbox"] = $this->checkbox;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isChecked(): bool
+    {
+        return $this->checkbox;
+    }
+}

--- a/src/Pages/PropertyItems/CreatedByPropertyItem.php
+++ b/src/Pages/PropertyItems/CreatedByPropertyItem.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Users\User;
+
+/**
+ * @psalm-import-type UserJson from \Notion\Users\User
+ *
+ * @psalm-type CreatedByItemJson = array{
+ *      id: string,
+ *      type: "created_by",
+ *      created_by: UserJson,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class CreatedByPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public User $user,
+    ) {
+    }
+
+    public static function create(User $user, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::CreatedBy);
+
+        return new self($metadata, $user);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var CreatedByItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $user = User::fromArray($array["created_by"]);
+
+        return new self($metadata, $user);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["created_by"] = $this->user->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/CreatedTimePropertyItem.php
+++ b/src/Pages/PropertyItems/CreatedTimePropertyItem.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type CreatedTimeItemJson = array{
+ *      id: string,
+ *      type: "created_time",
+ *      created_time: string,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class CreatedTimePropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public DateTimeImmutable $createdTime,
+    ) {
+    }
+
+    public static function create(DateTimeImmutable $createdTime, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::CreatedTime);
+
+        return new self($metadata, $createdTime);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var CreatedTimeItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $createdTime = new DateTimeImmutable($array["created_time"]);
+
+        return new self($metadata, $createdTime);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["created_time"] = $this->createdTime->format("Y-m-d\TH:i:s.uP");
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/DatePropertyItem.php
+++ b/src/Pages/PropertyItems/DatePropertyItem.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Common\Date as CommonDate;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type DateItemJson = array{
+ *      id: string,
+ *      type: "date",
+ *      date: array{
+ *          start: string,
+ *          end?: string|null,
+ *      }|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class DatePropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public CommonDate|null $date,
+    ) {
+    }
+
+    public static function create(CommonDate|null $date, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Date);
+
+        return new self($metadata, $date);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var DateItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $date = $array["date"] !== null ? CommonDate::fromArray($array["date"]) : null;
+
+        return new self($metadata, $date);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["date"] = $this->date?->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->date === null;
+    }
+}

--- a/src/Pages/PropertyItems/EmailPropertyItem.php
+++ b/src/Pages/PropertyItems/EmailPropertyItem.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type EmailItemJson = array{
+ *      id: string,
+ *      type: "email",
+ *      email: string|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class EmailPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public string|null $email,
+    ) {
+    }
+
+    public static function create(string|null $email, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Email);
+
+        return new self($metadata, $email);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var EmailItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $email = $array["email"] ?? null;
+
+        return new self($metadata, $email);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["email"] = $this->email;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->email === null;
+    }
+}

--- a/src/Pages/PropertyItems/FilesPropertyItem.php
+++ b/src/Pages/PropertyItems/FilesPropertyItem.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Common\File;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-import-type FileJson from \Notion\Common\File
+ *
+ * @psalm-type FilesItemJson = array{
+ *      id: string,
+ *      type: "files",
+ *      files: FileJson[],
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class FilesPropertyItem implements PropertyItemInterface
+{
+    /** @param list<File> $files */
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public array $files,
+    ) {
+    }
+
+    /** @param list<File> $files */
+    public static function create(array $files, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Files);
+
+        return new self($metadata, $files);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var FilesItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        /** @var list<File> $files */
+        $files = array_map(fn(array $f) => File::fromArray($f), $array["files"] ?? []);
+
+        return new self($metadata, $files);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["files"] = array_map(fn(File $f) => $f->toArray(), $this->files);
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->files);
+    }
+}

--- a/src/Pages/PropertyItems/FormulaPropertyItem.php
+++ b/src/Pages/PropertyItems/FormulaPropertyItem.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Common\Date;
+use Notion\Pages\Properties\FormulaType;
+use Notion\Pages\Properties\PropertyType;
+use stdClass;
+
+/**
+ * @psalm-type FormulaItemJson = array{
+ *      id: string,
+ *      type: "formula",
+ *      formula: array{
+ *          type: string,
+ *          string?: string|null,
+ *          number?: int|float|null,
+ *          boolean?: bool|null,
+ *          date?: array{
+ *              start: string,
+ *              end?: string|null,
+ *              time_zone?: string|null,
+ *          }|null,
+ *          unsupported?: array<empty, empty>|stdClass,
+ *      },
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class FormulaPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public FormulaType $formulaType,
+        public string|null $string = null,
+        public int|float|null $number = null,
+        public bool|null $boolean = null,
+        public Date|null $date = null,
+        public bool $unsupported = false,
+    ) {
+    }
+
+    public static function createString(string $string, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Formula);
+
+        return new self($metadata, FormulaType::String, string: $string);
+    }
+
+    public static function createNumber(int|float $number, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Formula);
+
+        return new self($metadata, FormulaType::Number, number: $number);
+    }
+
+    public static function createBoolean(bool $boolean, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Formula);
+
+        return new self($metadata, FormulaType::Boolean, boolean: $boolean);
+    }
+
+    public static function createDate(Date $date, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Formula);
+
+        return new self($metadata, FormulaType::Date, date: $date);
+    }
+
+    public static function createUnsupported(string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Formula);
+
+        return new self($metadata, FormulaType::Unsupported, unsupported: true);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var FormulaItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+
+        /** @var array<string, mixed> $formula */
+        $formula = $array["formula"] ?? [];
+        $typeString = isset($formula["type"]) && is_string($formula["type"]) ? $formula["type"] : "unsupported";
+        $type = FormulaType::tryFrom($typeString) ?? FormulaType::Unsupported;
+
+        $string = isset($formula["string"]) && is_string($formula["string"]) ? $formula["string"] : null;
+        $number = isset($formula["number"]) && (is_int($formula["number"]) || is_float($formula["number"]))
+            ? $formula["number"]
+            : null;
+        $boolean = isset($formula["boolean"]) && is_bool($formula["boolean"]) ? $formula["boolean"] : null;
+
+        /** @psalm-var array{start: string, end?: string|null}|null $dateArray */
+        $dateArray = isset($formula["date"]) && is_array($formula["date"]) ? $formula["date"] : null;
+        $date = $dateArray !== null ? Date::fromArray($dateArray) : null;
+        $unsupported = $type === FormulaType::Unsupported;
+
+        return new self($metadata, $type, $string, $number, $boolean, $date, $unsupported);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+
+        /** @var array<string, mixed> $formula */
+        $formula = ["type" => $this->formulaType->value];
+
+        if ($this->formulaType === FormulaType::String) {
+            $formula["string"] = $this->string;
+        } elseif ($this->formulaType === FormulaType::Number) {
+            $formula["number"] = $this->number;
+        } elseif ($this->formulaType === FormulaType::Boolean) {
+            $formula["boolean"] = $this->boolean;
+        } elseif ($this->formulaType === FormulaType::Date) {
+            $formula["date"] = $this->date?->toArray();
+        } else {
+            $formula["unsupported"] = new stdClass();
+        }
+
+        $array["formula"] = $formula;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isString(): bool
+    {
+        return $this->formulaType === FormulaType::String;
+    }
+
+    public function isNumber(): bool
+    {
+        return $this->formulaType === FormulaType::Number;
+    }
+
+    public function isBoolean(): bool
+    {
+        return $this->formulaType === FormulaType::Boolean;
+    }
+
+    public function isDate(): bool
+    {
+        return $this->formulaType === FormulaType::Date;
+    }
+
+    public function isUnsupported(): bool
+    {
+        return $this->formulaType === FormulaType::Unsupported;
+    }
+}

--- a/src/Pages/PropertyItems/LastEditedByPropertyItem.php
+++ b/src/Pages/PropertyItems/LastEditedByPropertyItem.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Users\User;
+
+/**
+ * @psalm-import-type UserJson from \Notion\Users\User
+ *
+ * @psalm-type LastEditedByItemJson = array{
+ *      id: string,
+ *      type: "last_edited_by",
+ *      last_edited_by: UserJson,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class LastEditedByPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public User $user,
+    ) {
+    }
+
+    public static function create(User $user, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::LastEditedBy);
+
+        return new self($metadata, $user);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var LastEditedByItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $user = User::fromArray($array["last_edited_by"]);
+
+        return new self($metadata, $user);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["last_edited_by"] = $this->user->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/LastEditedTimePropertyItem.php
+++ b/src/Pages/PropertyItems/LastEditedTimePropertyItem.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type LastEditedTimeItemJson = array{
+ *      id: string,
+ *      type: "last_edited_time",
+ *      last_edited_time: string,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class LastEditedTimePropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public DateTimeImmutable $lastEditedTime,
+    ) {
+    }
+
+    public static function create(DateTimeImmutable $lastEditedTime, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::LastEditedTime);
+
+        return new self($metadata, $lastEditedTime);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var LastEditedTimeItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $lastEditedTime = new DateTimeImmutable($array["last_edited_time"]);
+
+        return new self($metadata, $lastEditedTime);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["last_edited_time"] = $this->lastEditedTime->format("Y-m-d\TH:i:s.uP");
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/MultiSelectPropertyItem.php
+++ b/src/Pages/PropertyItems/MultiSelectPropertyItem.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\DataSources\Properties\SelectOption;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-import-type SelectOptionJson from \Notion\DataSources\Properties\SelectOption
+ *
+ * @psalm-type MultiSelectItemJson = array{
+ *      id: string,
+ *      type: "multi_select",
+ *      multi_select: SelectOptionJson[],
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class MultiSelectPropertyItem implements PropertyItemInterface
+{
+    /** @param list<SelectOption> $options */
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public array $options,
+    ) {
+    }
+
+    /** @param list<SelectOption> $options */
+    public static function create(array $options, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::MultiSelect);
+
+        return new self($metadata, $options);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var MultiSelectItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        /** @var list<SelectOption> $options */
+        $options = array_map(
+            fn(array $option) => SelectOption::fromArray($option),
+            $array["multi_select"] ?? [],
+        );
+
+        return new self($metadata, $options);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["multi_select"] = array_map(fn(SelectOption $o) => $o->toArray(), $this->options);
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->options);
+    }
+}

--- a/src/Pages/PropertyItems/NumberPropertyItem.php
+++ b/src/Pages/PropertyItems/NumberPropertyItem.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type NumberItemJson = array{
+ *      id: string,
+ *      type: "number",
+ *      number: int|float|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class NumberPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public int|float|null $number,
+    ) {
+    }
+
+    public static function create(int|float|null $number, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Number);
+
+        return new self($metadata, $number);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var NumberItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $number = $array["number"] ?? null;
+
+        return new self($metadata, $number);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["number"] = $this->number;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->number === null;
+    }
+}

--- a/src/Pages/PropertyItems/PeoplePropertyItem.php
+++ b/src/Pages/PropertyItems/PeoplePropertyItem.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Users\User;
+
+/**
+ * @psalm-import-type UserJson from \Notion\Users\User
+ *
+ * @psalm-type PeopleItemJson = array{
+ *      id: string,
+ *      type: "people",
+ *      people: UserJson|list<UserJson>,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class PeoplePropertyItem implements PropertyItemInterface
+{
+    /**
+     * @param list<User> $people
+     */
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public array $people,
+        public User|null $user = null,
+    ) {
+    }
+
+    public static function create(User $user, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::People);
+
+        return new self($metadata, [$user], $user);
+    }
+
+    /**
+     * @param list<User> $people
+     */
+    public static function createMultiple(array $people, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::People);
+        $user = $people[0] ?? null;
+
+        return new self($metadata, $people, $user);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var PeopleItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+
+        /** @var UserJson|list<UserJson> $rawPeople */
+        $rawPeople = $array["people"];
+
+        if (isset($rawPeople[0]) || empty($rawPeople)) {
+            /** @var list<UserJson> $rawPeople */
+            $people = array_map(fn(array $u) => User::fromArray($u), $rawPeople);
+            $user = $people[0] ?? null;
+        } else {
+            /** @var UserJson $rawPeople */
+            $singleUser = User::fromArray($rawPeople);
+            $people = [$singleUser];
+            $user = $singleUser;
+        }
+
+        return new self($metadata, $people, $user);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        if (count($this->people) === 1 && $this->user !== null) {
+            $array["people"] = $this->user->toArray();
+        } else {
+            $array["people"] = array_map(fn(User $u) => $u->toArray(), $this->people);
+        }
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->people);
+    }
+}

--- a/src/Pages/PropertyItems/PhoneNumberPropertyItem.php
+++ b/src/Pages/PropertyItems/PhoneNumberPropertyItem.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type PhoneNumberItemJson = array{
+ *      id: string,
+ *      type: "phone_number",
+ *      phone_number: string|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class PhoneNumberPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public string|null $phoneNumber,
+    ) {
+    }
+
+    public static function create(string|null $phoneNumber, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::PhoneNumber);
+
+        return new self($metadata, $phoneNumber);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var PhoneNumberItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $phoneNumber = $array["phone_number"] ?? null;
+
+        return new self($metadata, $phoneNumber);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["phone_number"] = $this->phoneNumber;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->phoneNumber === null;
+    }
+}

--- a/src/Pages/PropertyItems/PropertyItemFactory.php
+++ b/src/Pages/PropertyItems/PropertyItemFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+final readonly class PropertyItemFactory
+{
+    /**
+     * @param array<string, mixed> $array
+     */
+    public static function fromArray(array $array): PropertyItemInterface|PropertyItemList
+    {
+        $object = isset($array["object"]) && is_string($array["object"]) ? $array["object"] : null;
+
+        if ($object === "list") {
+            return PropertyItemList::fromArray($array);
+        }
+
+        $type = isset($array["type"]) && is_string($array["type"]) ? $array["type"] : "";
+
+        return match ($type) {
+            PropertyType::Title->value          => TitlePropertyItem::fromArray($array),
+            PropertyType::RichText->value       => RichTextPropertyItem::fromArray($array),
+            PropertyType::Number->value         => NumberPropertyItem::fromArray($array),
+            PropertyType::Select->value         => SelectPropertyItem::fromArray($array),
+            PropertyType::MultiSelect->value    => MultiSelectPropertyItem::fromArray($array),
+            PropertyType::Date->value           => DatePropertyItem::fromArray($array),
+            PropertyType::Formula->value        => FormulaPropertyItem::fromArray($array),
+            PropertyType::Relation->value       => RelationPropertyItem::fromArray($array),
+            PropertyType::Rollup->value         => RollupPropertyItem::fromArray($array),
+            PropertyType::People->value         => PeoplePropertyItem::fromArray($array),
+            PropertyType::Files->value          => FilesPropertyItem::fromArray($array),
+            PropertyType::Checkbox->value       => CheckboxPropertyItem::fromArray($array),
+            PropertyType::Url->value            => UrlPropertyItem::fromArray($array),
+            PropertyType::Email->value          => EmailPropertyItem::fromArray($array),
+            PropertyType::PhoneNumber->value    => PhoneNumberPropertyItem::fromArray($array),
+            PropertyType::CreatedTime->value    => CreatedTimePropertyItem::fromArray($array),
+            PropertyType::CreatedBy->value      => CreatedByPropertyItem::fromArray($array),
+            PropertyType::LastEditedTime->value => LastEditedTimePropertyItem::fromArray($array),
+            PropertyType::LastEditedBy->value   => LastEditedByPropertyItem::fromArray($array),
+            PropertyType::Status->value         => StatusPropertyItem::fromArray($array),
+            PropertyType::UniqueId->value       => UniqueIdPropertyItem::fromArray($array),
+            default                             => UnknownPropertyItem::fromArray($array),
+        };
+    }
+}

--- a/src/Pages/PropertyItems/PropertyItemInterface.php
+++ b/src/Pages/PropertyItems/PropertyItemInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+/** @psalm-immutable */
+interface PropertyItemInterface
+{
+    /** @internal */
+    public static function fromArray(array $array): self;
+
+    /** @internal */
+    public function toArray(): array;
+
+    public function metadata(): PropertyItemMetadata;
+}

--- a/src/Pages/PropertyItems/PropertyItemList.php
+++ b/src/Pages/PropertyItems/PropertyItemList.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use UnexpectedValueException;
+
+/**
+ * @psalm-immutable
+ */
+final readonly class PropertyItemList
+{
+    /**
+     * @param list<PropertyItemInterface> $results
+     */
+    private function __construct(
+        public array $results,
+        public string|null $nextCursor,
+        public bool $hasMore,
+        public PropertyItemMetadata $propertyItem,
+    ) {
+    }
+
+    /**
+     * @param list<PropertyItemInterface> $results
+     */
+    public static function create(
+        array $results,
+        string|null $nextCursor,
+        bool $hasMore,
+        PropertyItemMetadata $propertyItem,
+    ): self {
+        return new self($results, $nextCursor, $hasMore, $propertyItem);
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     */
+    public static function fromArray(array $array): self
+    {
+        /** @var list<array<string, mixed>> $rawResults */
+        $rawResults = isset($array["results"]) && is_array($array["results"]) ? array_values($array["results"]) : [];
+        /** @var list<PropertyItemInterface> $results */
+        $results = array_map(
+            function (array $item): PropertyItemInterface {
+                $parsed = PropertyItemFactory::fromArray($item);
+                if ($parsed instanceof PropertyItemList) {
+                    throw new UnexpectedValueException("Nested property item list in results is not supported.");
+                }
+                return $parsed;
+            },
+            $rawResults,
+        );
+
+        $nextCursor = isset($array["next_cursor"]) && is_string($array["next_cursor"])
+            ? $array["next_cursor"]
+            : null;
+        $hasMore = (bool) ($array["has_more"] ?? false);
+
+        /** @var array<string, mixed> $rawPropItem */
+        $rawPropItem = isset($array["property_item"]) && is_array($array["property_item"])
+            ? $array["property_item"]
+            : [];
+
+        if (empty($rawPropItem)) {
+            $rawPropItem = [
+                "id" => $array["id"] ?? "",
+                "type" => $array["type"] ?? "unknown",
+                "next_url" => $array["next_url"] ?? null,
+            ];
+        }
+
+        $propertyItem = PropertyItemMetadata::fromArray($rawPropItem);
+
+        return new self($results, $nextCursor, $hasMore, $propertyItem);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            "object" => "list",
+            "type" => "property_item",
+            "results" => array_map(fn(PropertyItemInterface $item) => $item->toArray(), $this->results),
+            "next_cursor" => $this->nextCursor,
+            "has_more" => $this->hasMore,
+            "property_item" => $this->propertyItem->toArray(),
+        ];
+    }
+
+    public function id(): string
+    {
+        return $this->propertyItem->id;
+    }
+
+    public function type(): PropertyType
+    {
+        return $this->propertyItem->type;
+    }
+
+    public function nextUrl(): string|null
+    {
+        return $this->propertyItem->nextUrl;
+    }
+
+    public function isTitle(): bool
+    {
+        return $this->propertyItem->type === PropertyType::Title;
+    }
+
+    public function isRichText(): bool
+    {
+        return $this->propertyItem->type === PropertyType::RichText;
+    }
+
+    public function isRelation(): bool
+    {
+        return $this->propertyItem->type === PropertyType::Relation;
+    }
+
+    public function isPeople(): bool
+    {
+        return $this->propertyItem->type === PropertyType::People;
+    }
+
+    public function isRollup(): bool
+    {
+        return $this->propertyItem->type === PropertyType::Rollup;
+    }
+}

--- a/src/Pages/PropertyItems/PropertyItemMetadata.php
+++ b/src/Pages/PropertyItems/PropertyItemMetadata.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type PropertyItemMetadataJson = array{
+ *     id: string,
+ *     type: string,
+ *     object?: string,
+ *     next_url?: string|null,
+ *     ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class PropertyItemMetadata
+{
+    private function __construct(
+        public string $id,
+        public PropertyType $type,
+        public string|null $nextUrl = null,
+        private string|null $unknownType = null,
+    ) {
+    }
+
+    /** @psalm-mutation-free */
+    public static function create(string $id, PropertyType $type, string|null $nextUrl = null): self
+    {
+        return new self($id, $type, $nextUrl);
+    }
+
+    /**
+     * @param PropertyItemMetadataJson $array
+     *
+     * @internal
+     */
+    public static function fromArray(array $array): self
+    {
+        $type = PropertyType::tryFrom($array["type"]) ?? PropertyType::Unknown;
+        $nextUrl = $array["next_url"] ?? null;
+
+        return new self(
+            $array["id"],
+            $type,
+            $nextUrl,
+            $type === PropertyType::Unknown ? $array["type"] : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $type = $this->type !== PropertyType::Unknown ? $this->type->value : $this->unknownType;
+
+        $array = [
+            "object" => "property_item",
+            "id"     => $this->id,
+            "type"   => $type,
+        ];
+
+        if ($this->nextUrl !== null) {
+            $array["next_url"] = $this->nextUrl;
+        }
+
+        return $array;
+    }
+}

--- a/src/Pages/PropertyItems/RelationPropertyItem.php
+++ b/src/Pages/PropertyItems/RelationPropertyItem.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type RelationItemJson = array{
+ *      id: string,
+ *      type: "relation",
+ *      relation: array{ id: string },
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class RelationPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public string $pageId,
+    ) {
+    }
+
+    public static function create(string $pageId, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Relation);
+
+        return new self($metadata, $pageId);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var RelationItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $pageId = $array["relation"]["id"];
+
+        return new self($metadata, $pageId);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["relation"] = ["id" => $this->pageId];
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/RichTextPropertyItem.php
+++ b/src/Pages/PropertyItems/RichTextPropertyItem.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Common\RichText;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-import-type RichTextJson from \Notion\Common\RichText
+ *
+ * @psalm-type RichTextItemJson = array{
+ *      id: string,
+ *      type: "rich_text",
+ *      rich_text: RichTextJson,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class RichTextPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public RichText $richText,
+    ) {
+    }
+
+    public static function create(RichText $richText, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::RichText);
+
+        return new self($metadata, $richText);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var RichTextItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $richText = RichText::fromArray($array["rich_text"]);
+
+        return new self($metadata, $richText);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["rich_text"] = $this->richText->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/RollupPropertyItem.php
+++ b/src/Pages/PropertyItems/RollupPropertyItem.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Common\Date;
+use Notion\DataSources\Properties\RollupFunction;
+use Notion\Pages\Properties\PropertyType;
+use stdClass;
+
+/**
+ * @psalm-type RollupItemJson = array{
+ *      id: string,
+ *      type: "rollup",
+ *      rollup: array{
+ *          type: string,
+ *          function: string,
+ *          number?: int|float|null,
+ *          date?: array{
+ *              start: string,
+ *              end?: string|null,
+ *              time_zone?: string|null,
+ *          }|null,
+ *          array?: list<mixed>,
+ *          incomplete?: array<empty, empty>|stdClass,
+ *          unsupported?: array<empty, empty>|stdClass,
+ *      },
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class RollupPropertyItem implements PropertyItemInterface
+{
+    /**
+     * @param list<mixed> $array
+     */
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public RollupType $rollupType,
+        public RollupFunction $function,
+        public int|float|null $number = null,
+        public Date|null $date = null,
+        public array $array = [],
+        public bool $incomplete = false,
+        public bool $unsupported = false,
+    ) {
+    }
+
+    public static function createNumber(
+        RollupFunction $function,
+        int|float|null $number,
+        string $id = "",
+    ): self {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Rollup);
+
+        return new self($metadata, RollupType::Number, $function, number: $number);
+    }
+
+    public static function createDate(
+        RollupFunction $function,
+        Date|null $date,
+        string $id = "",
+    ): self {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Rollup);
+
+        return new self($metadata, RollupType::Date, $function, date: $date);
+    }
+
+    /**
+     * @param list<mixed> $array
+     */
+    public static function createArray(
+        RollupFunction $function,
+        array $array,
+        string $id = "",
+    ): self {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Rollup);
+
+        return new self($metadata, RollupType::Array, $function, array: $array);
+    }
+
+    public static function createIncomplete(RollupFunction $function, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Rollup);
+
+        return new self($metadata, RollupType::Incomplete, $function, incomplete: true);
+    }
+
+    public static function createUnsupported(RollupFunction $function, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Rollup);
+
+        return new self($metadata, RollupType::Unsupported, $function, unsupported: true);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var RollupItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+
+        /** @var array{type: string, function: string, number?: int|float|null, date?: array{start: string, end?: string|null}|null, array?: list<mixed>} $data */
+        $data = $array["rollup"];
+
+        $rollupType = RollupType::from($data["type"]);
+        $function = RollupFunction::from($data["function"]);
+
+        $number = isset($data["number"]) && (is_int($data["number"]) || is_float($data["number"]))
+            ? $data["number"]
+            : null;
+
+        $date = isset($data["date"])
+            ? Date::fromArray($data["date"])
+            : null;
+
+        /** @var list<mixed> $arrayValues */
+        $arrayValues = $rollupType === RollupType::Array && isset($data["array"])
+            ? $data["array"]
+            : [];
+
+        $incomplete = $rollupType === RollupType::Incomplete;
+        $unsupported = $rollupType === RollupType::Unsupported;
+
+        return new self(
+            $metadata,
+            $rollupType,
+            $function,
+            number: $number,
+            date: $date,
+            array: $arrayValues,
+            incomplete: $incomplete,
+            unsupported: $unsupported,
+        );
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+
+        /** @var array<string, mixed> $rollup */
+        $rollup = [
+            "type" => $this->rollupType->value,
+            "function" => $this->function->value,
+        ];
+
+        if ($this->rollupType === RollupType::Number) {
+            $rollup["number"] = $this->number;
+        } elseif ($this->rollupType === RollupType::Date) {
+            $rollup["date"] = $this->date?->toArray();
+        } elseif ($this->rollupType === RollupType::Array) {
+            $rollup["array"] = $this->array;
+        } elseif ($this->rollupType === RollupType::Incomplete) {
+            $rollup["incomplete"] = new stdClass();
+        } else {
+            $rollup["unsupported"] = new stdClass();
+        }
+
+        $array["rollup"] = $rollup;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isNumber(): bool
+    {
+        return $this->rollupType === RollupType::Number;
+    }
+
+    public function isDate(): bool
+    {
+        return $this->rollupType === RollupType::Date;
+    }
+
+    public function isArray(): bool
+    {
+        return $this->rollupType === RollupType::Array;
+    }
+
+    public function isIncomplete(): bool
+    {
+        return $this->rollupType === RollupType::Incomplete;
+    }
+
+    public function isUnsupported(): bool
+    {
+        return $this->rollupType === RollupType::Unsupported;
+    }
+
+    public function isEmpty(): bool
+    {
+        return match ($this->rollupType) {
+            RollupType::Number => $this->number === null,
+            RollupType::Date => $this->date === null,
+            RollupType::Array => empty($this->array),
+            RollupType::Incomplete, RollupType::Unsupported => true,
+        };
+    }
+}

--- a/src/Pages/PropertyItems/RollupType.php
+++ b/src/Pages/PropertyItems/RollupType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+enum RollupType: string
+{
+    case Array = "array";
+    case Date = "date";
+    case Incomplete = "incomplete";
+    case Number = "number";
+    case Unsupported = "unsupported";
+}

--- a/src/Pages/PropertyItems/SelectPropertyItem.php
+++ b/src/Pages/PropertyItems/SelectPropertyItem.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\DataSources\Properties\SelectOption;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type SelectItemJson = array{
+ *      id: string,
+ *      type: "select",
+ *      select: array{ id: string, name: string, color: string }|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class SelectPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public SelectOption|null $option,
+    ) {
+    }
+
+    public static function create(SelectOption|null $option, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Select);
+
+        return new self($metadata, $option);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var SelectItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $option = $array["select"] ? SelectOption::fromArray($array["select"]) : null;
+
+        return new self($metadata, $option);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["select"] = $this->option?->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->option === null;
+    }
+}

--- a/src/Pages/PropertyItems/StatusPropertyItem.php
+++ b/src/Pages/PropertyItems/StatusPropertyItem.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\DataSources\Properties\StatusOption;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type StatusItemJson = array{
+ *      id: string,
+ *      type: "status",
+ *      status: array{ id: string, name: string, color: string }|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class StatusPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public StatusOption|null $option,
+    ) {
+    }
+
+    public static function create(StatusOption|null $option, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Status);
+
+        return new self($metadata, $option);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var StatusItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $option = $array["status"] ? StatusOption::fromArray($array["status"]) : null;
+
+        return new self($metadata, $option);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["status"] = $this->option?->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->option === null;
+    }
+}

--- a/src/Pages/PropertyItems/TitlePropertyItem.php
+++ b/src/Pages/PropertyItems/TitlePropertyItem.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Common\RichText;
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-import-type RichTextJson from \Notion\Common\RichText
+ *
+ * @psalm-type TitleItemJson = array{
+ *      id: string,
+ *      type: "title",
+ *      title: RichTextJson,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class TitlePropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public RichText $title,
+    ) {
+    }
+
+    public static function create(RichText $title, string $id = "title"): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Title);
+
+        return new self($metadata, $title);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var TitleItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $title = RichText::fromArray($array["title"]);
+
+        return new self($metadata, $title);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["title"] = $this->title->toArray();
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/UniqueIdPropertyItem.php
+++ b/src/Pages/PropertyItems/UniqueIdPropertyItem.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type UniqueIdItemJson = array{
+ *      id: string,
+ *      type: "unique_id",
+ *      unique_id: array{
+ *          number: int,
+ *          prefix: string|null,
+ *      },
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class UniqueIdPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public int $number,
+        public string|null $prefix,
+    ) {
+    }
+
+    public static function create(int $number, string|null $prefix = null, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::UniqueId);
+
+        return new self($metadata, $number, $prefix);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var UniqueIdItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+
+        $number = $array["unique_id"]["number"];
+        $prefix = $array["unique_id"]["prefix"];
+
+        return new self($metadata, $number, $prefix);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["unique_id"] = [
+            "number" => $this->number,
+            "prefix" => $this->prefix,
+        ];
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/UnknownPropertyItem.php
+++ b/src/Pages/PropertyItems/UnknownPropertyItem.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type UnknownItemJson = array{
+ *      id: string,
+ *      type: string,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class UnknownPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        private array $data,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function create(string $id, string $type, array $data = []): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Unknown);
+
+        return new self($metadata, $data);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var UnknownItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+
+        return new self($metadata, $array);
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Pages/PropertyItems/UrlPropertyItem.php
+++ b/src/Pages/PropertyItems/UrlPropertyItem.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Notion\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+
+/**
+ * @psalm-type UrlItemJson = array{
+ *      id: string,
+ *      type: "url",
+ *      url: string|null,
+ *      ...
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class UrlPropertyItem implements PropertyItemInterface
+{
+    private function __construct(
+        private PropertyItemMetadata $metadata,
+        public string|null $url,
+    ) {
+    }
+
+    public static function create(string|null $url, string $id = ""): self
+    {
+        $metadata = PropertyItemMetadata::create($id, PropertyType::Url);
+
+        return new self($metadata, $url);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var UrlItemJson $array */
+        $metadata = PropertyItemMetadata::fromArray($array);
+        $url = $array["url"] ?? null;
+
+        return new self($metadata, $url);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+        $array["url"] = $this->url;
+
+        return $array;
+    }
+
+    public function metadata(): PropertyItemMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->url === null;
+    }
+}

--- a/tests/Integration/PagesTest.php
+++ b/tests/Integration/PagesTest.php
@@ -6,6 +6,8 @@ use Notion\Common\Emoji;
 use Notion\Exceptions\ApiException;
 use Notion\Pages\Page;
 use Notion\Pages\PageParent;
+use Notion\Pages\PropertyItems\PropertyItemList;
+use Notion\Pages\PropertyItems\TitlePropertyItem;
 use PHPUnit\Framework\TestCase;
 
 class PagesTest extends TestCase
@@ -74,5 +76,41 @@ class PagesTest extends TestCase
 
         $this->expectException(ApiException::class);
         $client->pages()->update($page);
+    }
+
+    public function test_find_property_item_list(): void
+    {
+        $client = Helper::client();
+
+        $page = Helper::newPage()
+            ->changeTitle("Page with title to retrieve");
+
+        $page = $client->pages()->create($page);
+
+        $property = $client->pages()->findProperty($page->id, "title");
+
+        $this->assertInstanceOf(PropertyItemList::class, $property);
+        $this->assertTrue($property->isTitle());
+        $this->assertNotEmpty($property->results);
+        $firstItem = $property->results[0];
+        $this->assertInstanceOf(TitlePropertyItem::class, $firstItem);
+        $this->assertSame("Page with title to retrieve", $firstItem->title->plainText);
+
+        $client->pages()->delete($page);
+    }
+
+    public function test_find_inexistent_property(): void
+    {
+        $client = Helper::client();
+
+        $page = Helper::newPage();
+        $page = $client->pages()->create($page);
+
+        $this->expectException(ApiException::class);
+        try {
+            $client->pages()->findProperty($page->id, "inexistent-property-id");
+        } finally {
+            $client->pages()->delete($page);
+        }
     }
 }

--- a/tests/Unit/Pages/PropertyItems/CheckboxPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/CheckboxPropertyItemTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\CheckboxPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class CheckboxPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = CheckboxPropertyItem::create(true, "chk-id");
+
+        $this->assertSame("chk-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Checkbox, $item->metadata()->type);
+        $this->assertTrue($item->isChecked());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "checkbox",
+            "checkbox" => true,
+        ];
+
+        $item = CheckboxPropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertTrue($item->checkbox);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/CreatedByPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/CreatedByPropertyItemTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\CreatedByPropertyItem;
+use Notion\Users\User;
+use PHPUnit\Framework\TestCase;
+
+class CreatedByPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $user = User::create("user-id");
+        $item = CreatedByPropertyItem::create($user, "cb-id");
+
+        $this->assertSame("cb-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::CreatedBy, $item->metadata()->type);
+        $this->assertSame($user, $item->user);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "cb-id",
+            "type" => "created_by",
+            "created_by" => [
+                "object" => "user",
+                "id" => "23345d4f-cf71-4a70-89a5-226c95a6eaae",
+                "name" => "Test User",
+                "avatar_url" => null,
+                "type" => "person",
+                "person" => [
+                    "email" => "avo@example.org",
+                ],
+            ],
+        ];
+
+        $item = CreatedByPropertyItem::fromArray($array);
+
+        $this->assertSame("cb-id", $item->metadata()->id);
+        $this->assertSame("Test User", $item->user->name);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "cb-id",
+            "type" => "created_by",
+            "created_by" => [
+                "object" => "user",
+                "id" => "23345d4f-cf71-4a70-89a5-226c95a6eaae",
+                "name" => "Test User",
+                "type" => "person",
+                "person" => [
+                    "email" => "avo@example.org",
+                ],
+            ],
+        ], $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/CreatedTimePropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/CreatedTimePropertyItemTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\CreatedTimePropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class CreatedTimePropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $time = new DateTimeImmutable("2020-03-17T19:10:04.968Z");
+        $item = CreatedTimePropertyItem::create($time, "time-id");
+
+        $this->assertSame("time-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::CreatedTime, $item->metadata()->type);
+        $this->assertSame($time, $item->createdTime);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "created_time",
+            "created_time" => "2020-03-17T19:10:04.968000+00:00",
+        ];
+
+        $item = CreatedTimePropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/DatePropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/DatePropertyItemTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Common\Date;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\DatePropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class DatePropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $date = Date::create(new DateTimeImmutable("2021-05-11T11:00:00.000Z"));
+        $item = DatePropertyItem::create($date, "date-id");
+
+        $this->assertSame("date-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Date, $item->metadata()->type);
+        $this->assertSame($date, $item->date);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "i%3Ahj",
+            "type" => "date",
+            "date" => [
+                "start" => "2021-05-11T11:00:00.000-04:00",
+                "end" => null,
+                "time_zone" => null,
+            ],
+        ];
+
+        $item = DatePropertyItem::fromArray($array);
+
+        $this->assertSame("i%3Ahj", $item->metadata()->id);
+        $this->assertNotNull($item->date);
+        $this->assertSame("2021-05-11T11:00:00.000-04:00", $item->date->start->format("Y-m-d\TH:i:s.vP"));
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "i%3Ahj",
+            "type" => "date",
+            "date" => [
+                "start" => "2021-05-11T11:00:00.000000-04:00",
+                "end" => null,
+            ],
+        ], $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = DatePropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/EmailPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/EmailPropertyItemTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\EmailPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class EmailPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = EmailPropertyItem::create("test@example.com", "email-id");
+
+        $this->assertSame("email-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Email, $item->metadata()->type);
+        $this->assertSame("test@example.com", $item->email);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "email",
+            "email" => "hello@test.com",
+        ];
+
+        $item = EmailPropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertSame("hello@test.com", $item->email);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = EmailPropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/FilesPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/FilesPropertyItemTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Common\File;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\FilesPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class FilesPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $file = File::createExternal("https://example.com/image.png")->changeName("image.png");
+        $item = FilesPropertyItem::create([$file], "files-id");
+
+        $this->assertSame("files-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Files, $item->metadata()->type);
+        $this->assertCount(1, $item->files);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "files",
+            "files" => [
+                [
+                    "type" => "external",
+                    "name" => "Space Wallpaper",
+                    "external" => [
+                        "url" => "https://website.domain/images/space.png",
+                    ],
+                ],
+            ],
+        ];
+
+        $item = FilesPropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertCount(1, $item->files);
+        $this->assertSame("Space Wallpaper", $item->files[0]->name);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "files",
+            "files" => [
+                [
+                    "type" => "external",
+                    "name" => "Space Wallpaper",
+                    "external" => [
+                        "url" => "https://website.domain/images/space.png",
+                    ],
+                ],
+            ],
+        ], $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = FilesPropertyItem::create([]);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/FormulaPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/FormulaPropertyItemTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Common\Date;
+use Notion\Pages\Properties\FormulaType;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\FormulaPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class FormulaPropertyItemTest extends TestCase
+{
+    public function test_create_number(): void
+    {
+        $item = FormulaPropertyItem::createNumber(1234, "formula-id");
+
+        $this->assertSame("formula-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Formula, $item->metadata()->type);
+        $this->assertTrue($item->isNumber());
+        $this->assertSame(1234, $item->number);
+        $this->assertFalse($item->isString());
+    }
+
+    public function test_create_string(): void
+    {
+        $item = FormulaPropertyItem::createString("result");
+
+        $this->assertTrue($item->isString());
+        $this->assertSame("result", $item->string);
+    }
+
+    public function test_create_boolean(): void
+    {
+        $item = FormulaPropertyItem::createBoolean(true);
+
+        $this->assertTrue($item->isBoolean());
+        $this->assertTrue($item->boolean);
+    }
+
+    public function test_create_date(): void
+    {
+        $date = Date::create(new DateTimeImmutable("2021-05-11T11:00:00.000Z"));
+        $item = FormulaPropertyItem::createDate($date);
+
+        $this->assertTrue($item->isDate());
+        $this->assertSame($date, $item->date);
+    }
+
+    public function test_create_unsupported(): void
+    {
+        $item = FormulaPropertyItem::createUnsupported();
+
+        $this->assertTrue($item->isUnsupported());
+        $this->assertTrue($item->unsupported);
+    }
+
+    public function test_from_array_number(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "formula",
+            "formula" => [
+                "type" => "number",
+                "number" => 1234,
+            ],
+        ];
+
+        $item = FormulaPropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertTrue($item->isNumber());
+        $this->assertSame(1234, $item->number);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_from_array_unsupported(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "formula",
+            "formula" => [
+                "type" => "unsupported",
+                "unsupported" => new \stdClass(),
+            ],
+        ];
+
+        $item = FormulaPropertyItem::fromArray($array);
+
+        $this->assertTrue($item->isUnsupported());
+        $this->assertEquals($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/LastEditedByPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/LastEditedByPropertyItemTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\LastEditedByPropertyItem;
+use Notion\Users\User;
+use PHPUnit\Framework\TestCase;
+
+class LastEditedByPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $user = User::create("user-id");
+        $item = LastEditedByPropertyItem::create($user, "leb-id");
+
+        $this->assertSame("leb-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::LastEditedBy, $item->metadata()->type);
+        $this->assertSame($user, $item->user);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "leb-id",
+            "type" => "last_edited_by",
+            "last_edited_by" => [
+                "object" => "user",
+                "id" => "23345d4f-cf71-4a70-89a5-226c95a6eaae",
+                "name" => "Test User",
+                "avatar_url" => null,
+                "type" => "person",
+                "person" => [
+                    "email" => "avo@example.org",
+                ],
+            ],
+        ];
+
+        $item = LastEditedByPropertyItem::fromArray($array);
+
+        $this->assertSame("leb-id", $item->metadata()->id);
+        $this->assertSame("Test User", $item->user->name);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "leb-id",
+            "type" => "last_edited_by",
+            "last_edited_by" => [
+                "object" => "user",
+                "id" => "23345d4f-cf71-4a70-89a5-226c95a6eaae",
+                "name" => "Test User",
+                "type" => "person",
+                "person" => [
+                    "email" => "avo@example.org",
+                ],
+            ],
+        ], $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/LastEditedTimePropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/LastEditedTimePropertyItemTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\LastEditedTimePropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class LastEditedTimePropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $time = new DateTimeImmutable("2020-03-17T19:10:04.968Z");
+        $item = LastEditedTimePropertyItem::create($time, "let-id");
+
+        $this->assertSame("let-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::LastEditedTime, $item->metadata()->type);
+        $this->assertSame($time, $item->lastEditedTime);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "let-id",
+            "type" => "last_edited_time",
+            "last_edited_time" => "2020-03-17T19:10:04.968000+00:00",
+        ];
+
+        $item = LastEditedTimePropertyItem::fromArray($array);
+
+        $this->assertSame("let-id", $item->metadata()->id);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/MultiSelectPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/MultiSelectPropertyItemTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\DataSources\Properties\SelectOption;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\MultiSelectPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class MultiSelectPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $option = SelectOption::fromName("Tag 1");
+        $item = MultiSelectPropertyItem::create([$option], "ms-id");
+
+        $this->assertSame("ms-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::MultiSelect, $item->metadata()->type);
+        $this->assertCount(1, $item->options);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "z%7D%5C%3C",
+            "type" => "multi_select",
+            "multi_select" => [
+                [
+                    "id" => "91e6959e-7690-4f55-b8dd-d3da9debac45",
+                    "name" => "A",
+                    "color" => "orange",
+                ],
+            ],
+        ];
+
+        $item = MultiSelectPropertyItem::fromArray($array);
+
+        $this->assertSame("z%7D%5C%3C", $item->metadata()->id);
+        $this->assertCount(1, $item->options);
+        $this->assertSame("A", $item->options[0]->name);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "z%7D%5C%3C",
+            "type" => "multi_select",
+            "multi_select" => [
+                [
+                    "id" => "91e6959e-7690-4f55-b8dd-d3da9debac45",
+                    "name" => "A",
+                    "color" => "orange",
+                ],
+            ],
+        ], $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = MultiSelectPropertyItem::create([]);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/NumberPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/NumberPropertyItemTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\NumberPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class NumberPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = NumberPropertyItem::create(42, "num-id");
+
+        $this->assertSame("num-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Number, $item->metadata()->type);
+        $this->assertSame(42, $item->number);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "XpXf",
+            "type" => "number",
+            "number" => 1234,
+        ];
+
+        $item = NumberPropertyItem::fromArray($array);
+
+        $this->assertSame("XpXf", $item->metadata()->id);
+        $this->assertSame(1234, $item->number);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = NumberPropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/PeoplePropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/PeoplePropertyItemTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\PeoplePropertyItem;
+use Notion\Users\User;
+use PHPUnit\Framework\TestCase;
+
+class PeoplePropertyItemTest extends TestCase
+{
+    public function test_create_single(): void
+    {
+        $user = User::create("user-123");
+        $item = PeoplePropertyItem::create($user, "people-id");
+
+        $this->assertSame("people-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::People, $item->metadata()->type);
+        $this->assertSame($user, $item->user);
+        $this->assertCount(1, $item->people);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array_single_object(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "people-id",
+            "type" => "people",
+            "people" => [
+                "object" => "user",
+                "id" => "285e5768-3fdc-4742-ab9e-125f9050f3b8",
+                "name" => "Example Avo",
+                "avatar_url" => null,
+                "type" => "person",
+                "person" => [
+                    "email" => "avo@example.org",
+                ],
+            ],
+        ];
+
+        $item = PeoplePropertyItem::fromArray($array);
+
+        $this->assertSame("people-id", $item->metadata()->id);
+        $this->assertNotNull($item->user);
+        $this->assertSame("Example Avo", $item->user->name);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "people-id",
+            "type" => "people",
+            "people" => [
+                "object" => "user",
+                "id" => "285e5768-3fdc-4742-ab9e-125f9050f3b8",
+                "name" => "Example Avo",
+                "type" => "person",
+                "person" => [
+                    "email" => "avo@example.org",
+                ],
+            ],
+        ], $item->toArray());
+    }
+
+    public function test_from_array_array_of_users(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "people-id",
+            "type" => "people",
+            "people" => [
+                [
+                    "object" => "user",
+                    "id" => "285e5768-3fdc-4742-ab9e-125f9050f3b8",
+                    "name" => "Example Avo",
+                    "avatar_url" => null,
+                    "type" => "person",
+                    "person" => [
+                        "email" => "avo@example.org",
+                    ],
+                ],
+            ],
+        ];
+
+        $item = PeoplePropertyItem::fromArray($array);
+
+        $this->assertCount(1, $item->people);
+        $this->assertSame("Example Avo", $item->people[0]->name);
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/PhoneNumberPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/PhoneNumberPropertyItemTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\PhoneNumberPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class PhoneNumberPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = PhoneNumberPropertyItem::create("415-000-1111", "phone-id");
+
+        $this->assertSame("phone-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::PhoneNumber, $item->metadata()->type);
+        $this->assertSame("415-000-1111", $item->phoneNumber);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "phone_number",
+            "phone_number" => "415-000-1111",
+        ];
+
+        $item = PhoneNumberPropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertSame("415-000-1111", $item->phoneNumber);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = PhoneNumberPropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/PropertyItemFactoryTest.php
+++ b/tests/Unit/Pages/PropertyItems/PropertyItemFactoryTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\PropertyItems\CheckboxPropertyItem;
+use Notion\Pages\PropertyItems\CreatedByPropertyItem;
+use Notion\Pages\PropertyItems\CreatedTimePropertyItem;
+use Notion\Pages\PropertyItems\DatePropertyItem;
+use Notion\Pages\PropertyItems\EmailPropertyItem;
+use Notion\Pages\PropertyItems\FilesPropertyItem;
+use Notion\Pages\PropertyItems\FormulaPropertyItem;
+use Notion\Pages\PropertyItems\LastEditedByPropertyItem;
+use Notion\Pages\PropertyItems\LastEditedTimePropertyItem;
+use Notion\Pages\PropertyItems\MultiSelectPropertyItem;
+use Notion\Pages\PropertyItems\NumberPropertyItem;
+use Notion\Pages\PropertyItems\PeoplePropertyItem;
+use Notion\Pages\PropertyItems\PhoneNumberPropertyItem;
+use Notion\Pages\PropertyItems\PropertyItemFactory;
+use Notion\Pages\PropertyItems\PropertyItemList;
+use Notion\Pages\PropertyItems\RelationPropertyItem;
+use Notion\Pages\PropertyItems\RichTextPropertyItem;
+use Notion\Pages\PropertyItems\RollupPropertyItem;
+use Notion\Pages\PropertyItems\SelectPropertyItem;
+use Notion\Pages\PropertyItems\StatusPropertyItem;
+use Notion\Pages\PropertyItems\TitlePropertyItem;
+use Notion\Pages\PropertyItems\UniqueIdPropertyItem;
+use Notion\Pages\PropertyItems\UnknownPropertyItem;
+use Notion\Pages\PropertyItems\UrlPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class PropertyItemFactoryTest extends TestCase
+{
+    public function test_list(): void
+    {
+        $array = [
+            "object" => "list",
+            "results" => [],
+            "next_cursor" => null,
+            "has_more" => false,
+            "type" => "property_item",
+            "property_item" => [
+                "id" => "title",
+                "type" => "title",
+                "next_url" => null,
+            ],
+        ];
+
+        $res = PropertyItemFactory::fromArray($array);
+        $this->assertInstanceOf(PropertyItemList::class, $res);
+    }
+
+    public function test_all_property_item_types(): void
+    {
+        $types = [
+            "title" => [
+                "array" => [
+                    "object" => "property_item", "id" => "1", "type" => "title",
+                    "title" => ["plain_text" => "t", "href" => null, "annotations" => [
+                        "bold" => false, "italic" => false, "strikethrough" => false,
+                        "underline" => false, "code" => false, "color" => "default",
+                    ], "type" => "text", "text" => ["content" => "t"]],
+                ],
+                "expected" => TitlePropertyItem::class,
+            ],
+            "rich_text" => [
+                "array" => [
+                    "object" => "property_item", "id" => "2", "type" => "rich_text",
+                    "rich_text" => ["plain_text" => "r", "href" => null, "annotations" => [
+                        "bold" => false, "italic" => false, "strikethrough" => false,
+                        "underline" => false, "code" => false, "color" => "default",
+                    ], "type" => "text", "text" => ["content" => "r"]],
+                ],
+                "expected" => RichTextPropertyItem::class,
+            ],
+            "number" => [
+                "array" => ["object" => "property_item", "id" => "3", "type" => "number", "number" => 123],
+                "expected" => NumberPropertyItem::class,
+            ],
+            "select" => [
+                "array" => ["object" => "property_item", "id" => "4", "type" => "select", "select" => null],
+                "expected" => SelectPropertyItem::class,
+            ],
+            "multi_select" => [
+                "array" => [
+                    "object" => "property_item", "id" => "5", "type" => "multi_select",
+                    "multi_select" => [],
+                ],
+                "expected" => MultiSelectPropertyItem::class,
+            ],
+            "date" => [
+                "array" => ["object" => "property_item", "id" => "6", "type" => "date", "date" => null],
+                "expected" => DatePropertyItem::class,
+            ],
+            "formula" => [
+                "array" => [
+                    "object" => "property_item", "id" => "7", "type" => "formula",
+                    "formula" => ["type" => "number", "number" => 5],
+                ],
+                "expected" => FormulaPropertyItem::class,
+            ],
+            "relation" => [
+                "array" => [
+                    "object" => "property_item", "id" => "8", "type" => "relation",
+                    "relation" => ["id" => "page-id"],
+                ],
+                "expected" => RelationPropertyItem::class,
+            ],
+            "rollup" => [
+                "array" => [
+                    "object" => "property_item", "id" => "9", "type" => "rollup",
+                    "rollup" => ["type" => "number", "function" => "count", "number" => 1],
+                ],
+                "expected" => RollupPropertyItem::class,
+            ],
+            "people" => [
+                "array" => [
+                    "object" => "property_item", "id" => "10", "type" => "people",
+                    "people" => [
+                        "object" => "user", "id" => "u1", "name" => "User", "avatar_url" => null,
+                        "type" => "person", "person" => ["email" => "u@test.com"],
+                    ],
+                ],
+                "expected" => PeoplePropertyItem::class,
+            ],
+            "files" => [
+                "array" => ["object" => "property_item", "id" => "11", "type" => "files", "files" => []],
+                "expected" => FilesPropertyItem::class,
+            ],
+            "checkbox" => [
+                "array" => ["object" => "property_item", "id" => "12", "type" => "checkbox", "checkbox" => true],
+                "expected" => CheckboxPropertyItem::class,
+            ],
+            "url" => [
+                "array" => ["object" => "property_item", "id" => "13", "type" => "url", "url" => "https://test.com"],
+                "expected" => UrlPropertyItem::class,
+            ],
+            "email" => [
+                "array" => ["object" => "property_item", "id" => "14", "type" => "email", "email" => "a@b.com"],
+                "expected" => EmailPropertyItem::class,
+            ],
+            "phone_number" => [
+                "array" => [
+                    "object" => "property_item", "id" => "15", "type" => "phone_number",
+                    "phone_number" => "123",
+                ],
+                "expected" => PhoneNumberPropertyItem::class,
+            ],
+            "created_time" => [
+                "array" => [
+                    "object" => "property_item", "id" => "16", "type" => "created_time",
+                    "created_time" => "2020-03-17T19:10:04.968Z",
+                ],
+                "expected" => CreatedTimePropertyItem::class,
+            ],
+            "created_by" => [
+                "array" => [
+                    "object" => "property_item", "id" => "17", "type" => "created_by",
+                    "created_by" => [
+                        "object" => "user", "id" => "u2", "name" => "Creator", "avatar_url" => null,
+                        "type" => "person", "person" => ["email" => "c@test.com"],
+                    ],
+                ],
+                "expected" => CreatedByPropertyItem::class,
+            ],
+            "last_edited_time" => [
+                "array" => [
+                    "object" => "property_item", "id" => "18", "type" => "last_edited_time",
+                    "last_edited_time" => "2020-03-17T19:10:04.968Z",
+                ],
+                "expected" => LastEditedTimePropertyItem::class,
+            ],
+            "last_edited_by" => [
+                "array" => [
+                    "object" => "property_item", "id" => "19", "type" => "last_edited_by",
+                    "last_edited_by" => [
+                        "object" => "user", "id" => "u3", "name" => "Editor", "avatar_url" => null,
+                        "type" => "person", "person" => ["email" => "e@test.com"],
+                    ],
+                ],
+                "expected" => LastEditedByPropertyItem::class,
+            ],
+            "status" => [
+                "array" => [
+                    "object" => "property_item", "id" => "20", "type" => "status",
+                    "status" => null,
+                ],
+                "expected" => StatusPropertyItem::class,
+            ],
+            "unique_id" => [
+                "array" => [
+                    "object" => "property_item", "id" => "21", "type" => "unique_id",
+                    "unique_id" => ["number" => 1, "prefix" => "A"],
+                ],
+                "expected" => UniqueIdPropertyItem::class,
+            ],
+            "unknown" => [
+                "array" => ["object" => "property_item", "id" => "22", "type" => "unsupported_type"],
+                "expected" => UnknownPropertyItem::class,
+            ],
+        ];
+
+        foreach ($types as $type => $info) {
+            $parsed = PropertyItemFactory::fromArray($info["array"]);
+            /** @var class-string $expected */
+            $expected = $info["expected"];
+            $this->assertInstanceOf($expected, $parsed, "Failed for type: {$type}");
+        }
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/PropertyItemListTest.php
+++ b/tests/Unit/Pages/PropertyItems/PropertyItemListTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Common\RichText;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\PropertyItemList;
+use Notion\Pages\PropertyItems\PropertyItemMetadata;
+use Notion\Pages\PropertyItems\RelationPropertyItem;
+use Notion\Pages\PropertyItems\TitlePropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class PropertyItemListTest extends TestCase
+{
+    public function test_title_property_item_list(): void
+    {
+        $array = [
+            "object" => "list",
+            "results" => [
+                [
+                    "object" => "property_item",
+                    "id" => "title",
+                    "type" => "title",
+                    "title" => [
+                        "plain_text" => "Page Title",
+                        "href" => null,
+                        "annotations" => [
+                            "bold" => false,
+                            "italic" => false,
+                            "strikethrough" => false,
+                            "underline" => false,
+                            "code" => false,
+                            "color" => "default",
+                        ],
+                        "type" => "text",
+                        "text" => ["content" => "Page Title"],
+                    ],
+                ],
+            ],
+            "next_cursor" => null,
+            "has_more" => false,
+            "type" => "property_item",
+            "property_item" => [
+                "id" => "title",
+                "next_url" => null,
+                "type" => "title",
+            ],
+        ];
+
+        $list = PropertyItemList::fromArray($array);
+
+        $this->assertCount(1, $list->results);
+        $this->assertInstanceOf(TitlePropertyItem::class, $list->results[0]);
+        $this->assertSame("title", $list->id());
+        $this->assertSame(PropertyType::Title, $list->type());
+        $this->assertNull($list->nextCursor);
+        $this->assertFalse($list->hasMore);
+        $this->assertNull($list->nextUrl());
+        $this->assertTrue($list->isTitle());
+        $this->assertFalse($list->isRichText());
+        $this->assertFalse($list->isRelation());
+        $this->assertFalse($list->isPeople());
+        $this->assertFalse($list->isRollup());
+
+        $expected = $array;
+        $expected["property_item"] = [
+            "object" => "property_item",
+            "id" => "title",
+            "type" => "title",
+        ];
+        $this->assertEquals($expected, $list->toArray());
+    }
+
+    public function test_relation_property_item_list_paginated(): void
+    {
+        $nextUrl = "http://api.notion.com/v1/pages/0e5235bf86aa4efb93aa772cce7eab71/properties/vYdV?start_cursor=123";
+        $array = [
+            "object" => "list",
+            "results" => [
+                [
+                    "object" => "property_item",
+                    "id" => "vYdV",
+                    "type" => "relation",
+                    "relation" => [
+                        "id" => "535c3fb2-95e6-4b37-a696-036e5eac5cf6",
+                    ],
+                ],
+            ],
+            "next_cursor" => "next-cursor-123",
+            "has_more" => true,
+            "type" => "property_item",
+            "property_item" => [
+                "id" => "vYdV",
+                "next_url" => $nextUrl,
+                "type" => "relation",
+            ],
+        ];
+
+        $list = PropertyItemList::fromArray($array);
+
+        $this->assertSame("next-cursor-123", $list->nextCursor);
+        $this->assertTrue($list->hasMore);
+        $this->assertSame($nextUrl, $list->nextUrl());
+        $this->assertInstanceOf(RelationPropertyItem::class, $list->results[0]);
+        $this->assertSame("535c3fb2-95e6-4b37-a696-036e5eac5cf6", $list->results[0]->pageId);
+    }
+
+    public function test_create(): void
+    {
+        $rel = RelationPropertyItem::create("page-123", "rel-1");
+        $meta = PropertyItemMetadata::create("rel-1", PropertyType::Relation);
+        $list = PropertyItemList::create([$rel], "cursor-xyz", false, $meta);
+
+        $this->assertSame("cursor-xyz", $list->nextCursor);
+        $this->assertFalse($list->hasMore);
+        $this->assertCount(1, $list->results);
+        $this->assertTrue($list->isRelation());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/PropertyItemMetadataTest.php
+++ b/tests/Unit/Pages/PropertyItems/PropertyItemMetadataTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\PropertyItemMetadata;
+use PHPUnit\Framework\TestCase;
+
+class PropertyItemMetadataTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $meta = PropertyItemMetadata::create("prop-id", PropertyType::Title, "http://example.com/next");
+
+        $this->assertSame("prop-id", $meta->id);
+        $this->assertSame(PropertyType::Title, $meta->type);
+        $this->assertSame("http://example.com/next", $meta->nextUrl);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "id" => "prop-123",
+            "type" => "checkbox",
+            "next_url" => null,
+        ];
+
+        $meta = PropertyItemMetadata::fromArray($array);
+
+        $this->assertSame("prop-123", $meta->id);
+        $this->assertSame(PropertyType::Checkbox, $meta->type);
+        $this->assertNull($meta->nextUrl);
+        $this->assertSame([
+            "object" => "property_item",
+            "id" => "prop-123",
+            "type" => "checkbox",
+        ], $meta->toArray());
+    }
+
+    public function test_unknown_type(): void
+    {
+        $array = [
+            "id" => "unknown-id",
+            "type" => "future_type",
+            "next_url" => "http://example.com",
+        ];
+
+        $meta = PropertyItemMetadata::fromArray($array);
+
+        $this->assertSame("unknown-id", $meta->id);
+        $this->assertSame(PropertyType::Unknown, $meta->type);
+        $this->assertSame([
+            "object" => "property_item",
+            "id" => "unknown-id",
+            "type" => "future_type",
+            "next_url" => "http://example.com",
+        ], $meta->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/RelationPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/RelationPropertyItemTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\RelationPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class RelationPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = RelationPropertyItem::create("page-uuid-123", "rel-id");
+
+        $this->assertSame("rel-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Relation, $item->metadata()->type);
+        $this->assertSame("page-uuid-123", $item->pageId);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "vYdV",
+            "type" => "relation",
+            "relation" => [
+                "id" => "535c3fb2-95e6-4b37-a696-036e5eac5cf6",
+            ],
+        ];
+
+        $item = RelationPropertyItem::fromArray($array);
+
+        $this->assertSame("vYdV", $item->metadata()->id);
+        $this->assertSame("535c3fb2-95e6-4b37-a696-036e5eac5cf6", $item->pageId);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/RichTextPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/RichTextPropertyItemTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Common\RichText;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\RichTextPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class RichTextPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $text = RichText::fromString("Hello world");
+        $item = RichTextPropertyItem::create($text, "rich-id");
+
+        $this->assertSame("rich-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::RichText, $item->metadata()->type);
+        $this->assertSame("Hello world", $item->richText->plainText);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "NVv^",
+            "type" => "rich_text",
+            "rich_text" => [
+                "plain_text" => "Hello world",
+                "href" => null,
+                "annotations" => [
+                    "bold" => false,
+                    "italic" => false,
+                    "strikethrough" => false,
+                    "underline" => false,
+                    "code" => false,
+                    "color" => "default",
+                ],
+                "type" => "text",
+                "text" => ["content" => "Hello world"],
+            ],
+        ];
+
+        $item = RichTextPropertyItem::fromArray($array);
+
+        $this->assertSame("NVv^", $item->metadata()->id);
+        $this->assertSame("Hello world", $item->richText->plainText);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/RollupPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/RollupPropertyItemTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use DateTimeImmutable;
+use Notion\Common\Date;
+use Notion\DataSources\Properties\RollupFunction;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\RollupPropertyItem;
+use Notion\Pages\PropertyItems\RollupType;
+use PHPUnit\Framework\TestCase;
+
+class RollupPropertyItemTest extends TestCase
+{
+    public function test_create_number(): void
+    {
+        $item = RollupPropertyItem::createNumber(RollupFunction::Count, 5, "prop-id");
+
+        $this->assertTrue($item->isNumber());
+        $this->assertFalse($item->isDate());
+        $this->assertSame(5, $item->number);
+        $this->assertSame(RollupFunction::Count, $item->function);
+        $this->assertSame(RollupType::Number, $item->rollupType);
+        $this->assertSame("prop-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Rollup, $item->metadata()->type);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_create_date(): void
+    {
+        $date = Date::create(new DateTimeImmutable("2021-10-07T14:42:00.000Z"));
+        $item = RollupPropertyItem::createDate(RollupFunction::LatestDate, $date);
+
+        $this->assertTrue($item->isDate());
+        $this->assertSame($date, $item->date);
+        $this->assertSame(RollupFunction::LatestDate, $item->function);
+        $this->assertSame(RollupType::Date, $item->rollupType);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_create_array(): void
+    {
+        $item = RollupPropertyItem::createArray(RollupFunction::ShowOriginal, [["foo" => "bar"]]);
+
+        $this->assertTrue($item->isArray());
+        $this->assertCount(1, $item->array);
+        $this->assertSame(RollupFunction::ShowOriginal, $item->function);
+        $this->assertSame(RollupType::Array, $item->rollupType);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_create_incomplete(): void
+    {
+        $item = RollupPropertyItem::createIncomplete(RollupFunction::Sum);
+
+        $this->assertTrue($item->isIncomplete());
+        $this->assertTrue($item->incomplete);
+        $this->assertSame(RollupFunction::Sum, $item->function);
+        $this->assertSame(RollupType::Incomplete, $item->rollupType);
+        $this->assertTrue($item->isEmpty());
+    }
+
+    public function test_create_unsupported(): void
+    {
+        $item = RollupPropertyItem::createUnsupported(RollupFunction::Median);
+
+        $this->assertTrue($item->isUnsupported());
+        $this->assertTrue($item->unsupported);
+        $this->assertSame(RollupFunction::Median, $item->function);
+        $this->assertSame(RollupType::Unsupported, $item->rollupType);
+        $this->assertTrue($item->isEmpty());
+    }
+
+    public function test_from_array_number(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "rollup_prop",
+            "type" => "rollup",
+            "rollup" => [
+                "type" => "number",
+                "function" => "count",
+                "number" => 42,
+            ],
+        ];
+
+        $item = RollupPropertyItem::fromArray($array);
+
+        $this->assertSame("rollup_prop", $item->metadata()->id);
+        $this->assertTrue($item->isNumber());
+        $this->assertSame(42, $item->number);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_empty_checks(): void
+    {
+        $numberEmpty = RollupPropertyItem::createNumber(RollupFunction::Count, null);
+        $this->assertTrue($numberEmpty->isEmpty());
+
+        $dateEmpty = RollupPropertyItem::createDate(RollupFunction::EarliestDate, null);
+        $this->assertTrue($dateEmpty->isEmpty());
+
+        $arrayEmpty = RollupPropertyItem::createArray(RollupFunction::ShowOriginal, []);
+        $this->assertTrue($arrayEmpty->isEmpty());
+    }
+
+    public function test_to_array_for_various_types(): void
+    {
+        $date = Date::create(new DateTimeImmutable("2021-10-07T14:42:00.000Z"));
+        $dateRollup = RollupPropertyItem::createDate(RollupFunction::LatestDate, $date);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "",
+            "type" => "rollup",
+            "rollup" => [
+                "type" => "date",
+                "function" => "latest_date",
+                "date" => $date->toArray(),
+            ],
+        ], $dateRollup->toArray());
+
+        $arrayRollup = RollupPropertyItem::createArray(RollupFunction::ShowOriginal, [["item" => 1]]);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "",
+            "type" => "rollup",
+            "rollup" => [
+                "type" => "array",
+                "function" => "show_original",
+                "array" => [["item" => 1]],
+            ],
+        ], $arrayRollup->toArray());
+
+        $incompleteRollup = RollupPropertyItem::createIncomplete(RollupFunction::Sum);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "",
+            "type" => "rollup",
+            "rollup" => [
+                "type" => "incomplete",
+                "function" => "sum",
+                "incomplete" => new \stdClass(),
+            ],
+        ], $incompleteRollup->toArray());
+
+        $unsupportedRollup = RollupPropertyItem::createUnsupported(RollupFunction::Median);
+        $this->assertEquals([
+            "object" => "property_item",
+            "id" => "",
+            "type" => "rollup",
+            "rollup" => [
+                "type" => "unsupported",
+                "function" => "median",
+                "unsupported" => new \stdClass(),
+            ],
+        ], $unsupportedRollup->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/SelectPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/SelectPropertyItemTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\DataSources\Properties\SelectOption;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\SelectPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class SelectPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $option = SelectOption::fromName("Option 1");
+        $item = SelectPropertyItem::create($option, "sel-id");
+
+        $this->assertSame("sel-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Select, $item->metadata()->type);
+        $this->assertSame("Option 1", $item->option?->name);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "%7CtzR",
+            "type" => "select",
+            "select" => [
+                "name" => "Option 1",
+                "id" => "64190ec9-e963-47cb-bc37-6a71d6b71206",
+                "color" => "orange",
+            ],
+        ];
+
+        $item = SelectPropertyItem::fromArray($array);
+
+        $this->assertSame("%7CtzR", $item->metadata()->id);
+        $this->assertSame("Option 1", $item->option?->name);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_null_option(): void
+    {
+        $item = SelectPropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/StatusPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/StatusPropertyItemTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\DataSources\Properties\StatusOption;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\StatusPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class StatusPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $option = StatusOption::fromName("In Progress");
+        $item = StatusPropertyItem::create($option, "status-id");
+
+        $this->assertSame("status-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Status, $item->metadata()->type);
+        $this->assertSame("In Progress", $item->option?->name);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "status-id",
+            "type" => "status",
+            "status" => [
+                "name" => "Done",
+                "id" => "status-uuid",
+                "color" => "green",
+            ],
+        ];
+
+        $item = StatusPropertyItem::fromArray($array);
+
+        $this->assertSame("status-id", $item->metadata()->id);
+        $this->assertSame("Done", $item->option?->name);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = StatusPropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/TitlePropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/TitlePropertyItemTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Common\RichText;
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\TitlePropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class TitlePropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $text = RichText::fromString("Page Title");
+        $item = TitlePropertyItem::create($text, "title-id");
+
+        $this->assertSame("title-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Title, $item->metadata()->type);
+        $this->assertSame("Page Title", $item->title->plainText);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "title",
+            "type" => "title",
+            "title" => [
+                "plain_text" => "Page Title",
+                "href" => null,
+                "annotations" => [
+                    "bold" => false,
+                    "italic" => false,
+                    "strikethrough" => false,
+                    "underline" => false,
+                    "code" => false,
+                    "color" => "default",
+                ],
+                "type" => "text",
+                "text" => ["content" => "Page Title"],
+            ],
+        ];
+
+        $item = TitlePropertyItem::fromArray($array);
+
+        $this->assertSame("title", $item->metadata()->id);
+        $this->assertSame("Page Title", $item->title->plainText);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/UniqueIdPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/UniqueIdPropertyItemTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\UniqueIdPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class UniqueIdPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = UniqueIdPropertyItem::create(42, "TASK", "uid-id");
+
+        $this->assertSame("uid-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::UniqueId, $item->metadata()->type);
+        $this->assertSame(42, $item->number);
+        $this->assertSame("TASK", $item->prefix);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "uid-id",
+            "type" => "unique_id",
+            "unique_id" => [
+                "number" => 123,
+                "prefix" => "BUG",
+            ],
+        ];
+
+        $item = UniqueIdPropertyItem::fromArray($array);
+
+        $this->assertSame("uid-id", $item->metadata()->id);
+        $this->assertSame(123, $item->number);
+        $this->assertSame("BUG", $item->prefix);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/UnknownPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/UnknownPropertyItemTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\UnknownPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class UnknownPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = UnknownPropertyItem::create("unk-id", "some_future_type", ["key" => "val"]);
+
+        $this->assertSame("unk-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Unknown, $item->metadata()->type);
+        $this->assertSame(["key" => "val"], $item->toArray());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "unk-id",
+            "type" => "custom_type",
+            "custom_type" => "something",
+        ];
+
+        $item = UnknownPropertyItem::fromArray($array);
+
+        $this->assertSame("unk-id", $item->metadata()->id);
+        $this->assertSame($array, $item->toArray());
+    }
+}

--- a/tests/Unit/Pages/PropertyItems/UrlPropertyItemTest.php
+++ b/tests/Unit/Pages/PropertyItems/UrlPropertyItemTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Notion\Test\Unit\Pages\PropertyItems;
+
+use Notion\Pages\Properties\PropertyType;
+use Notion\Pages\PropertyItems\UrlPropertyItem;
+use PHPUnit\Framework\TestCase;
+
+class UrlPropertyItemTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $item = UrlPropertyItem::create("https://notion.so", "url-id");
+
+        $this->assertSame("url-id", $item->metadata()->id);
+        $this->assertSame(PropertyType::Url, $item->metadata()->type);
+        $this->assertSame("https://notion.so", $item->url);
+        $this->assertFalse($item->isEmpty());
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object" => "property_item",
+            "id" => "KpQq",
+            "type" => "url",
+            "url" => "https://notion.com/notiondevs",
+        ];
+
+        $item = UrlPropertyItem::fromArray($array);
+
+        $this->assertSame("KpQq", $item->metadata()->id);
+        $this->assertSame("https://notion.com/notiondevs", $item->url);
+        $this->assertSame($array, $item->toArray());
+    }
+
+    public function test_empty(): void
+    {
+        $item = UrlPropertyItem::create(null);
+        $this->assertTrue($item->isEmpty());
+    }
+}


### PR DESCRIPTION
Resolves #446

## Summary

Add support for retrieving individual page properties via Notion's `GET /v1/pages/{page_id}/properties/{property_id}` endpoint:

- Add `Notion\Pages\Client::findProperty(string $pageId, string $propertyId, ?string $startCursor = null, ?int $pageSize = null): PropertyItemInterface|PropertyItemList`.
- Add `PropertyItemInterface` and `PropertyItemMetadata` for individual property item responses.
- Add dedicated property item classes in `src/Pages/PropertyItems/` for all Notion property item types:
  - `CheckboxPropertyItem`, `CreatedByPropertyItem`, `CreatedTimePropertyItem`, `DatePropertyItem`, `EmailPropertyItem`, `FilesPropertyItem`, `FormulaPropertyItem`, `LastEditedByPropertyItem`, `LastEditedTimePropertyItem`, `MultiSelectPropertyItem`, `NumberPropertyItem`, `PeoplePropertyItem`, `PhoneNumberPropertyItem`, `RelationPropertyItem`, `RichTextPropertyItem`, `RollupPropertyItem`, `SelectPropertyItem`, `StatusPropertyItem`, `TitlePropertyItem`, `UniqueIdPropertyItem`, `UrlPropertyItem`, and `UnknownPropertyItem`.
- Add `PropertyItemList` to represent paginated responses (`"object": "list", "type": "property_item"`).
- Add `PropertyItemFactory` to parse response payloads into either `PropertyItemInterface` or `PropertyItemList`.
- Add unit tests for all property items, list, metadata, and factory.
- Add integration tests for retrieving property item lists and handling inexistent properties in `tests/Integration/PagesTest.php`.
- Document changes in `CHANGELOG.md`.