### PR TITLE
feat: support link preview and template mentions (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support link preview and template mentions in rich text (#447).
 - Support retrieving individual page properties (#446).
 - Support rollup data source properties (#445).
 - Support audio blocks (#444).

--- a/src/Common/Mention.php
+++ b/src/Common/Mention.php
@@ -7,13 +7,16 @@ use Notion\Users\User;
 /**
  * @psalm-import-type UserJson from \Notion\Users\User
  * @psalm-import-type DateJson from Date
+ * @psalm-import-type TemplateMentionJson from TemplateMention
  *
  * @psalm-type MentionJson = array{
- *      type: "page"|"database"|"user"|"date",
+ *      type: "page"|"database"|"user"|"date"|"link_preview"|"template_mention",
  *      page?: array{ id: string },
  *      database?: array{ id: string },
  *      user?: UserJson,
  *      date?: DateJson,
+ *      link_preview?: array{ url: string },
+ *      template_mention?: TemplateMentionJson,
  * }
  *
  * @psalm-immutable
@@ -26,6 +29,8 @@ final readonly class Mention
         public string|null $databaseId,
         public User|null $user,
         public Date|null $date,
+        public string|null $linkPreviewUrl = null,
+        public TemplateMention|null $templateMention = null,
     ) {
     }
 
@@ -49,6 +54,55 @@ final readonly class Mention
         return new self(MentionType::Date, null, null, null, $date);
     }
 
+    public static function linkPreview(string $url): self
+    {
+        return new self(
+            MentionType::LinkPreview,
+            null,
+            null,
+            null,
+            null,
+            linkPreviewUrl: $url,
+        );
+    }
+
+    public static function templateMention(TemplateMention $templateMention): self
+    {
+        return new self(
+            MentionType::TemplateMention,
+            null,
+            null,
+            null,
+            null,
+            templateMention: $templateMention,
+        );
+    }
+
+    public static function templateDate(TemplateMentionDateType $date): self
+    {
+        return self::templateMention(TemplateMention::date($date));
+    }
+
+    public static function templateUser(TemplateMentionUserType $user = TemplateMentionUserType::Me): self
+    {
+        return self::templateMention(TemplateMention::user($user));
+    }
+
+    public static function today(): self
+    {
+        return self::templateMention(TemplateMention::today());
+    }
+
+    public static function now(): self
+    {
+        return self::templateMention(TemplateMention::now());
+    }
+
+    public static function me(): self
+    {
+        return self::templateMention(TemplateMention::me());
+    }
+
     /**
      * @psalm-param MentionJson $array
      *
@@ -62,8 +116,12 @@ final readonly class Mention
         $databaseId = array_key_exists("database", $array) ? $array["database"]["id"] : null;
         $user = array_key_exists("user", $array) ? User::fromArray($array["user"]) : null;
         $date = array_key_exists("date", $array) ? Date::fromArray($array["date"]) : null;
+        $linkPreviewUrl = array_key_exists("link_preview", $array) ? $array["link_preview"]["url"] : null;
+        $templateMention = array_key_exists("template_mention", $array)
+            ? TemplateMention::fromArray($array["template_mention"])
+            : null;
 
-        return new self($type, $pageId, $databaseId, $user, $date);
+        return new self($type, $pageId, $databaseId, $user, $date, $linkPreviewUrl, $templateMention);
     }
 
     public function toArray(): array
@@ -81,6 +139,12 @@ final readonly class Mention
         }
         if ($this->isDate()) {
             $array["date"] = $this->date->toArray();
+        }
+        if ($this->isLinkPreview()) {
+            $array["link_preview"] = [ "url" => $this->linkPreviewUrl ];
+        }
+        if ($this->isTemplateMention()) {
+            $array["template_mention"] = $this->templateMention->toArray();
         }
 
         return $array;
@@ -116,5 +180,21 @@ final readonly class Mention
     public function isDate(): bool
     {
         return $this->type === MentionType::Date;
+    }
+
+    /**
+     * @psalm-assert-if-true string $this->linkPreviewUrl
+     */
+    public function isLinkPreview(): bool
+    {
+        return $this->type === MentionType::LinkPreview;
+    }
+
+    /**
+     * @psalm-assert-if-true TemplateMention $this->templateMention
+     */
+    public function isTemplateMention(): bool
+    {
+        return $this->type === MentionType::TemplateMention;
     }
 }

--- a/src/Common/MentionType.php
+++ b/src/Common/MentionType.php
@@ -8,4 +8,6 @@ enum MentionType: string
     case Database = "database";
     case User = "user";
     case Date = "date";
+    case LinkPreview = "link_preview";
+    case TemplateMention = "template_mention";
 }

--- a/src/Common/TemplateMention.php
+++ b/src/Common/TemplateMention.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Notion\Common;
+
+/**
+ * @psalm-type TemplateMentionJson = array{
+ *      type: "template_mention_date"|"template_mention_user",
+ *      template_mention_date?: string,
+ *      template_mention_user?: string,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class TemplateMention
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    private function __construct(
+        public TemplateMentionType $type,
+        public TemplateMentionDateType|null $templateMentionDate = null,
+        public TemplateMentionUserType|null $templateMentionUser = null,
+        public array $raw = [],
+    ) {
+    }
+
+    public static function date(TemplateMentionDateType $date): self
+    {
+        return new self(TemplateMentionType::Date, templateMentionDate: $date);
+    }
+
+    public static function user(TemplateMentionUserType $user = TemplateMentionUserType::Me): self
+    {
+        return new self(TemplateMentionType::User, templateMentionUser: $user);
+    }
+
+    public static function today(): self
+    {
+        return self::date(TemplateMentionDateType::Today);
+    }
+
+    public static function now(): self
+    {
+        return self::date(TemplateMentionDateType::Now);
+    }
+
+    public static function me(): self
+    {
+        return self::user(TemplateMentionUserType::Me);
+    }
+
+    /**
+     * @psalm-param TemplateMentionJson $array
+     *
+     * @internal
+     */
+    public static function fromArray(array $array): self
+    {
+        $type = TemplateMentionType::from($array["type"]);
+
+        $date = isset($array["template_mention_date"])
+            ? TemplateMentionDateType::from($array["template_mention_date"])
+            : null;
+
+        $user = isset($array["template_mention_user"])
+            ? TemplateMentionUserType::from($array["template_mention_user"])
+            : null;
+
+        /** @var array<string, mixed> $raw */
+        $raw = $array;
+
+        return new self($type, $date, $user, $raw);
+    }
+
+    public function toArray(): array
+    {
+        /** @var array<string, mixed> $array */
+        $array = array_merge($this->raw, [ "type" => $this->type->value ]);
+
+        if ($this->isDate()) {
+            $array["template_mention_date"] = $this->templateMentionDate->value;
+        }
+
+        if ($this->isUser()) {
+            $array["template_mention_user"] = $this->templateMentionUser->value;
+        }
+
+        return $array;
+    }
+
+    /**
+     * @psalm-assert-if-true TemplateMentionDateType $this->templateMentionDate
+     */
+    public function isDate(): bool
+    {
+        return $this->type === TemplateMentionType::Date;
+    }
+
+    /**
+     * @psalm-assert-if-true TemplateMentionUserType $this->templateMentionUser
+     */
+    public function isUser(): bool
+    {
+        return $this->type === TemplateMentionType::User;
+    }
+}

--- a/src/Common/TemplateMentionDateType.php
+++ b/src/Common/TemplateMentionDateType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Notion\Common;
+
+enum TemplateMentionDateType: string
+{
+    case Today = "today";
+    case Now = "now";
+}

--- a/src/Common/TemplateMentionType.php
+++ b/src/Common/TemplateMentionType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Notion\Common;
+
+enum TemplateMentionType: string
+{
+    case Date = "template_mention_date";
+    case User = "template_mention_user";
+}

--- a/src/Common/TemplateMentionUserType.php
+++ b/src/Common/TemplateMentionUserType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Notion\Common;
+
+enum TemplateMentionUserType: string
+{
+    case Me = "me";
+}

--- a/tests/Unit/Common/MentionTest.php
+++ b/tests/Unit/Common/MentionTest.php
@@ -6,6 +6,9 @@ use DateTimeImmutable;
 use Notion\Common\Date;
 use Notion\Common\Mention;
 use Notion\Common\MentionType;
+use Notion\Common\TemplateMention;
+use Notion\Common\TemplateMentionDateType;
+use Notion\Common\TemplateMentionUserType;
 use Notion\Users\User;
 use PHPUnit\Framework\TestCase;
 
@@ -99,6 +102,104 @@ class MentionTest extends TestCase
         $array = [
             "type" => "date",
             "date" => [ "start" => "2021-01-01T00:00:00.000000Z", "end" => null ],
+        ];
+        $mention = Mention::fromArray($array);
+
+        $this->assertEquals($array, $mention->toArray());
+    }
+
+    public function test_mention_link_preview(): void
+    {
+        $mention = Mention::linkPreview("https://notion.so");
+
+        $this->assertTrue($mention->isLinkPreview());
+        $this->assertEquals(MentionType::LinkPreview, $mention->type);
+        $this->assertEquals("https://notion.so", $mention->linkPreviewUrl);
+    }
+
+    public function test_mention_template_mention(): void
+    {
+        $template = TemplateMention::today();
+        $mention = Mention::templateMention($template);
+
+        $this->assertTrue($mention->isTemplateMention());
+        $this->assertEquals(MentionType::TemplateMention, $mention->type);
+        $this->assertEquals($template, $mention->templateMention);
+    }
+
+    public function test_mention_template_date(): void
+    {
+        $mention = Mention::templateDate(TemplateMentionDateType::Today);
+
+        $this->assertTrue($mention->isTemplateMention());
+        $this->assertEquals(TemplateMentionDateType::Today, $mention->templateMention?->templateMentionDate);
+    }
+
+    public function test_mention_template_user(): void
+    {
+        $mention = Mention::templateUser(TemplateMentionUserType::Me);
+
+        $this->assertTrue($mention->isTemplateMention());
+        $this->assertEquals(TemplateMentionUserType::Me, $mention->templateMention?->templateMentionUser);
+    }
+
+    public function test_mention_today(): void
+    {
+        $mention = Mention::today();
+
+        $this->assertTrue($mention->isTemplateMention());
+        $this->assertEquals(TemplateMentionDateType::Today, $mention->templateMention?->templateMentionDate);
+    }
+
+    public function test_mention_now(): void
+    {
+        $mention = Mention::now();
+
+        $this->assertTrue($mention->isTemplateMention());
+        $this->assertEquals(TemplateMentionDateType::Now, $mention->templateMention?->templateMentionDate);
+    }
+
+    public function test_mention_me(): void
+    {
+        $mention = Mention::me();
+
+        $this->assertTrue($mention->isTemplateMention());
+        $this->assertEquals(TemplateMentionUserType::Me, $mention->templateMention?->templateMentionUser);
+    }
+
+    public function test_link_preview_array_conversion(): void
+    {
+        $array = [
+            "type" => "link_preview",
+            "link_preview" => [ "url" => "https://notion.so" ],
+        ];
+        $mention = Mention::fromArray($array);
+
+        $this->assertEquals($array, $mention->toArray());
+    }
+
+    public function test_template_mention_date_array_conversion(): void
+    {
+        $array = [
+            "type" => "template_mention",
+            "template_mention" => [
+                "type" => "template_mention_date",
+                "template_mention_date" => "today",
+            ],
+        ];
+        $mention = Mention::fromArray($array);
+
+        $this->assertEquals($array, $mention->toArray());
+    }
+
+    public function test_template_mention_user_array_conversion(): void
+    {
+        $array = [
+            "type" => "template_mention",
+            "template_mention" => [
+                "type" => "template_mention_user",
+                "template_mention_user" => "me",
+            ],
         ];
         $mention = Mention::fromArray($array);
 

--- a/tests/Unit/Common/RichTextTest.php
+++ b/tests/Unit/Common/RichTextTest.php
@@ -155,4 +155,80 @@ class RichTextTest extends TestCase
 
         $this->assertEquals($array, $richText->toArray());
     }
+
+    public function test_create_from_link_preview_mention(): void
+    {
+        $mention = Mention::linkPreview("https://notion.so");
+        $richText = RichText::fromMention($mention);
+
+        $this->assertNotNull($richText->mention);
+        $this->assertTrue($richText->mention->isLinkPreview());
+        $this->assertEquals("https://notion.so", $richText->mention->linkPreviewUrl);
+    }
+
+    public function test_create_from_template_mention(): void
+    {
+        $mention = Mention::today();
+        $richText = RichText::fromMention($mention);
+
+        $this->assertNotNull($richText->mention);
+        $this->assertTrue($richText->mention->isTemplateMention());
+        $this->assertNotNull($richText->mention->templateMention);
+        $this->assertTrue($richText->mention->templateMention->isDate());
+    }
+
+    public function test_link_preview_mention_array_conversion(): void
+    {
+        $array = [
+            "plain_text" => "",
+            "href" => null,
+            "annotations" => [
+                "bold"          => false,
+                "italic"        => false,
+                "strikethrough" => false,
+                "underline"     => false,
+                "code"          => false,
+                "color"         => "default",
+            ],
+            "type" => "mention",
+            "mention" => [
+                "type" => "link_preview",
+                "link_preview" => [ "url" => "https://notion.so" ],
+            ],
+        ];
+        $richText = RichText::fromArray($array);
+
+        $this->assertEquals($array, $richText->toArray());
+        $this->assertNotNull($richText->mention);
+        $this->assertTrue($richText->mention->isLinkPreview());
+    }
+
+    public function test_template_mention_array_conversion(): void
+    {
+        $array = [
+            "plain_text" => "@Today",
+            "href" => null,
+            "annotations" => [
+                "bold"          => false,
+                "italic"        => false,
+                "strikethrough" => false,
+                "underline"     => false,
+                "code"          => false,
+                "color"         => "default",
+            ],
+            "type" => "mention",
+            "mention" => [
+                "type" => "template_mention",
+                "template_mention" => [
+                    "type" => "template_mention_date",
+                    "template_mention_date" => "today",
+                ],
+            ],
+        ];
+        $richText = RichText::fromArray($array);
+
+        $this->assertEquals($array, $richText->toArray());
+        $this->assertNotNull($richText->mention);
+        $this->assertTrue($richText->mention->isTemplateMention());
+    }
 }

--- a/tests/Unit/Common/TemplateMentionTest.php
+++ b/tests/Unit/Common/TemplateMentionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Notion\Test\Unit\Common;
+
+use Notion\Common\TemplateMention;
+use Notion\Common\TemplateMentionDateType;
+use Notion\Common\TemplateMentionType;
+use Notion\Common\TemplateMentionUserType;
+use PHPUnit\Framework\TestCase;
+
+class TemplateMentionTest extends TestCase
+{
+    public function test_template_mention_date(): void
+    {
+        $template = TemplateMention::date(TemplateMentionDateType::Today);
+
+        $this->assertTrue($template->isDate());
+        $this->assertFalse($template->isUser());
+        $this->assertSame(TemplateMentionType::Date, $template->type);
+        $this->assertSame(TemplateMentionDateType::Today, $template->templateMentionDate);
+        $this->assertNull($template->templateMentionUser);
+    }
+
+    public function test_template_mention_today(): void
+    {
+        $template = TemplateMention::today();
+
+        $this->assertTrue($template->isDate());
+        $this->assertSame(TemplateMentionDateType::Today, $template->templateMentionDate);
+    }
+
+    public function test_template_mention_now(): void
+    {
+        $template = TemplateMention::now();
+
+        $this->assertTrue($template->isDate());
+        $this->assertSame(TemplateMentionDateType::Now, $template->templateMentionDate);
+    }
+
+    public function test_template_mention_user(): void
+    {
+        $template = TemplateMention::user(TemplateMentionUserType::Me);
+
+        $this->assertTrue($template->isUser());
+        $this->assertFalse($template->isDate());
+        $this->assertSame(TemplateMentionType::User, $template->type);
+        $this->assertSame(TemplateMentionUserType::Me, $template->templateMentionUser);
+        $this->assertNull($template->templateMentionDate);
+    }
+
+    public function test_template_mention_me(): void
+    {
+        $template = TemplateMention::me();
+
+        $this->assertTrue($template->isUser());
+        $this->assertSame(TemplateMentionUserType::Me, $template->templateMentionUser);
+    }
+
+    public function test_template_mention_date_array_conversion(): void
+    {
+        $array = [
+            "type" => "template_mention_date",
+            "template_mention_date" => "today",
+        ];
+
+        $template = TemplateMention::fromArray($array);
+
+        $this->assertSame($array, $template->toArray());
+    }
+
+    public function test_template_mention_now_array_conversion(): void
+    {
+        $array = [
+            "type" => "template_mention_date",
+            "template_mention_date" => "now",
+        ];
+
+        $template = TemplateMention::fromArray($array);
+
+        $this->assertSame($array, $template->toArray());
+    }
+
+    public function test_template_mention_user_array_conversion(): void
+    {
+        $array = [
+            "type" => "template_mention_user",
+            "template_mention_user" => "me",
+        ];
+
+        $template = TemplateMention::fromArray($array);
+
+        $this->assertSame($array, $template->toArray());
+    }
+
+    public function test_preserve_additional_subtype_data(): void
+    {
+        $array = [
+            "type" => "template_mention_date",
+            "template_mention_date" => "today",
+            "custom_metadata" => "extra_value",
+        ];
+
+        /** @psalm-suppress InvalidArgument */
+        $template = TemplateMention::fromArray($array);
+
+        $this->assertSame($array, $template->toArray());
+    }
+}


### PR DESCRIPTION
Closes #447

## Summary
Support `link_preview` and `template_mention` rich-text mentions in accordance with the Notion API specifications:
- Add `LinkPreview` and `TemplateMention` cases to `MentionType` enum.
- Add `TemplateMentionType`, `TemplateMentionDateType`, and `TemplateMentionUserType` string-backed enums.
- Add `TemplateMention` model representing template mention objects, with typed factory methods (`date`, `user`, `today`, `now`, `me`) and serialization that preserves all subtype data.
- Update `Mention` model to expose `$linkPreviewUrl` and `$templateMention` properties, named constructors, and array conversions for `link_preview` and `template_mention`.
- Add unit tests for `TemplateMention`, `Mention`, and `RichText`.
- Document changes in `CHANGELOG.md`.