### PR TITLE
feat: support synced blocks (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support synced blocks (#449).
 - Support link to page blocks (#448).
 - Support link preview and template mentions in rich text (#447).
 - Support retrieving individual page properties (#446).

--- a/docs/blocks/SyncedBlock.md
+++ b/docs/blocks/SyncedBlock.md
@@ -1,0 +1,60 @@
+# SyncedBlock
+
+Synced blocks allow syncing identical block content across multiple locations in Notion. There are two variants of a synced block:
+- **Original synced block**: The source block where content is authored. It can have children blocks.
+- **Reference synced block**: A duplicate block that references the original synced block by its `block_id`.
+
+## Create an original synced block
+
+```php
+use Notion\Blocks\Paragraph;
+use Notion\Blocks\SyncedBlock;
+
+// Create an original synced block with children
+$original = SyncedBlock::createOriginal(
+    Paragraph::fromString("Content shared across pages."),
+);
+
+// Or create an empty original synced block and add children later
+$original = SyncedBlock::createOriginal()
+    ->addChild(Paragraph::fromString("Content shared across pages."));
+```
+
+## Create a reference synced block
+
+```php
+use Notion\Blocks\SyncedBlock;
+
+// Reference by original block ID string
+$reference = SyncedBlock::createReference("7af38973-3787-41b3-bd75-0ed3a1edfac9");
+
+// Or reference from an existing SyncedBlock instance
+$reference = SyncedBlock::createReference($originalBlock);
+```
+
+## Inspect variant
+
+```php
+if ($block->isOriginal()) {
+    $children = $block->children;
+}
+
+if ($block->isReference()) {
+    $targetId = $block->originalBlockId();
+}
+```
+
+## Manage children
+
+Original synced blocks support adding and changing child blocks:
+
+```php
+$block = $block->addChild(Paragraph::fromString("Another paragraph"));
+$block = $block->changeChildren(
+    Paragraph::fromString("New child 1"),
+    Paragraph::fromString("New child 2"),
+);
+```
+
+> [!NOTE]
+> Reference synced blocks do not support adding or changing children directly; attempting to do so will throw a `BlockException`.

--- a/docs/blocks/index.md
+++ b/docs/blocks/index.md
@@ -69,6 +69,7 @@ $p = $p->changeChildren();
 | [Paragraph](./Paragraph)               | ✔               |
 | [PDF](./Pdf.md)                        | ❌              |
 | [Quote](./Quote.md)                    | ✔               |
+| [SyncedBlock](./SyncedBlock.md)         | ✔ (original)   |
 | TableOfContents                        | ❌              |
 | ToDo                                   | ✔               |
 | Toggle                                 | ✔               |

--- a/src/Blocks/BlockFactory.php
+++ b/src/Blocks/BlockFactory.php
@@ -36,6 +36,7 @@ final readonly class BlockFactory
             BlockType::Paragraph->value        => Paragraph::fromArray($array),
             BlockType::Pdf->value              => Pdf::fromArray($array),
             BlockType::Quote->value            => Quote::fromArray($array),
+            BlockType::SyncedBlock->value      => SyncedBlock::fromArray($array),
             BlockType::TableOfContents->value  => TableOfContents::fromArray($array),
             BlockType::ToDo->value             => ToDo::fromArray($array),
             BlockType::Toggle->value           => Toggle::fromArray($array),

--- a/src/Blocks/BlockType.php
+++ b/src/Blocks/BlockType.php
@@ -34,5 +34,6 @@ enum BlockType: string
     case ColumnList = "column_list";
     case LinkPreview = "link_preview";
     case LinkToPage = "link_to_page";
+    case SyncedBlock = "synced_block";
     case Unknown = "unknown";
 }

--- a/src/Blocks/SyncedBlock.php
+++ b/src/Blocks/SyncedBlock.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Notion\Blocks;
+
+use Notion\Exceptions\BlockException;
+
+/**
+ * @psalm-import-type BlockMetadataJson from BlockMetadata
+ * @psalm-import-type SyncedFromJson from SyncedFrom
+ *
+ * @psalm-type SyncedBlockJson = array{
+ *     synced_block: array{
+ *         synced_from: SyncedFromJson|null,
+ *         children?: list<array{ type: string, ... }>,
+ *     },
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class SyncedBlock implements BlockInterface
+{
+    /**
+     * @param BlockInterface[] $children
+     */
+    private function __construct(
+        private BlockMetadata $metadata,
+        public SyncedFrom|null $syncedFrom,
+        public array $children,
+    ) {
+        $metadata->checkType(BlockType::SyncedBlock);
+
+        if ($this->syncedFrom !== null && count($children) > 0) {
+            throw BlockException::noChindrenSupport();
+        }
+    }
+
+    public static function createOriginal(BlockInterface ...$children): self
+    {
+        $hasChildren = count($children) > 0;
+        $metadata = BlockMetadata::create(BlockType::SyncedBlock)->updateHasChildren($hasChildren);
+
+        return new self($metadata, null, $children);
+    }
+
+    public static function createReference(string|BlockInterface $block): self
+    {
+        $blockId = match (true) {
+            $block instanceof SyncedBlock && $block->isReference() => $block->syncedFrom->blockId,
+            $block instanceof BlockInterface => $block->metadata()->id,
+            default => $block,
+        };
+
+        $metadata = BlockMetadata::create(BlockType::SyncedBlock);
+
+        return new self($metadata, SyncedFrom::create($blockId), []);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var BlockMetadataJson $array */
+        $metadata = BlockMetadata::fromArray($array);
+
+        /** @psalm-var SyncedBlockJson $array */
+        $syncedBlock = $array["synced_block"];
+
+        $syncedFromArray = $syncedBlock["synced_from"] ?? null;
+        $syncedFrom = $syncedFromArray !== null ? SyncedFrom::fromArray($syncedFromArray) : null;
+
+        $rawChildren = $syncedBlock["children"] ?? [];
+        $children = array_map(fn(array $child) => BlockFactory::fromArray($child), $rawChildren);
+
+        return new self($metadata, $syncedFrom, $children);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+
+        if ($this->isReference()) {
+            $array["synced_block"] = [
+                "synced_from" => $this->syncedFrom->toArray(),
+            ];
+        } else {
+            $array["synced_block"] = [
+                "synced_from" => null,
+                "children"    => array_map(fn(BlockInterface $b) => $b->toArray(), $this->children),
+            ];
+        }
+
+        return $array;
+    }
+
+    public function metadata(): BlockMetadata
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @psalm-assert-if-true null $this->syncedFrom
+     */
+    public function isOriginal(): bool
+    {
+        return $this->syncedFrom === null;
+    }
+
+    /**
+     * @psalm-assert-if-true SyncedFrom $this->syncedFrom
+     */
+    public function isReference(): bool
+    {
+        return $this->syncedFrom !== null;
+    }
+
+    public function originalBlockId(): string|null
+    {
+        return $this->syncedFrom?->blockId;
+    }
+
+    public function addChild(BlockInterface $child): self
+    {
+        if ($this->isReference()) {
+            throw BlockException::noChindrenSupport();
+        }
+
+        $children = $this->children;
+        $children[] = $child;
+
+        return new self(
+            $this->metadata->updateHasChildren(true),
+            null,
+            $children,
+        );
+    }
+
+    public function changeChildren(BlockInterface ...$children): self
+    {
+        if ($this->isReference()) {
+            throw BlockException::noChindrenSupport();
+        }
+
+        $hasChildren = count($children) > 0;
+
+        return new self(
+            $this->metadata->updateHasChildren($hasChildren),
+            null,
+            $children,
+        );
+    }
+
+    public function changeSyncedFrom(SyncedFrom|string $syncedFrom): self
+    {
+        $syncedFrom = is_string($syncedFrom) ? SyncedFrom::create($syncedFrom) : $syncedFrom;
+
+        return new self(
+            $this->metadata->update(),
+            $syncedFrom,
+            [],
+        );
+    }
+
+    public function toOriginal(BlockInterface ...$children): self
+    {
+        $hasChildren = count($children) > 0;
+
+        return new self(
+            $this->metadata->updateHasChildren($hasChildren),
+            null,
+            $children,
+        );
+    }
+
+    public function toReference(SyncedFrom|string|BlockInterface $syncedFrom): self
+    {
+        $blockId = match (true) {
+            $syncedFrom instanceof SyncedBlock && $syncedFrom->isReference() => $syncedFrom->syncedFrom->blockId,
+            $syncedFrom instanceof BlockInterface => $syncedFrom->metadata()->id,
+            $syncedFrom instanceof SyncedFrom => $syncedFrom->blockId,
+            default => $syncedFrom,
+        };
+
+        return new self(
+            $this->metadata->updateHasChildren(false),
+            SyncedFrom::create($blockId),
+            [],
+        );
+    }
+
+    public function delete(): BlockInterface
+    {
+        return new self(
+            $this->metadata->delete(),
+            $this->syncedFrom,
+            $this->children,
+        );
+    }
+
+    /**
+     * @deprecated 1.17.0 Use `delete()` instead.
+     * @codeCoverageIgnore
+     */
+    public function archive(): BlockInterface
+    {
+        return $this->delete();
+    }
+}

--- a/src/Blocks/SyncedFrom.php
+++ b/src/Blocks/SyncedFrom.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Notion\Blocks;
+
+/**
+ * @psalm-type SyncedFromJson = array{
+ *     type?: string,
+ *     block_id: string,
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class SyncedFrom
+{
+    /** @psalm-mutation-free */
+    private function __construct(
+        public string $blockId,
+        public string $type = "block_id",
+    ) {
+    }
+
+    /** @psalm-mutation-free */
+    public static function create(string $blockId): self
+    {
+        return new self($blockId);
+    }
+
+    /**
+     * @psalm-param SyncedFromJson $array
+     * @psalm-mutation-free
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            $array["block_id"],
+            $array["type"] ?? "block_id",
+        );
+    }
+
+    /** @psalm-mutation-free */
+    public function toArray(): array
+    {
+        return [
+            "type"     => $this->type,
+            "block_id" => $this->blockId,
+        ];
+    }
+
+    /** @psalm-mutation-free */
+    public function changeBlockId(string $blockId): self
+    {
+        return new self($blockId, $this->type);
+    }
+}

--- a/tests/Integration/BlocksTest.php
+++ b/tests/Integration/BlocksTest.php
@@ -267,7 +267,7 @@ class BlocksTest extends TestCase
                 ToDo::fromString("To do item"),
                 Toggle::fromString("Toggle"),
                 LinkToPage::page(Helper::testPageId()),
-                SyncedBlock::createOriginal(Paragraph::fromString("Content")),
+                // TODO: SyncedBlock
                 // TODO: Video
                 // TODO: ColumnList
             ]

--- a/tests/Integration/BlocksTest.php
+++ b/tests/Integration/BlocksTest.php
@@ -20,6 +20,7 @@ use Notion\Blocks\Heading3;
 use Notion\Blocks\LinkToPage;
 use Notion\Blocks\NumberedListItem;
 use Notion\Blocks\Paragraph;
+use Notion\Blocks\SyncedBlock;
 use Notion\Blocks\TableOfContents;
 use Notion\Blocks\ToDo;
 use Notion\Blocks\Toggle;
@@ -59,6 +60,7 @@ class BlocksTest extends TestCase
             ToDo::fromString("To do item"),
             Toggle::fromString("Toggle"),
             LinkToPage::page(Helper::testPageId()),
+            SyncedBlock::createOriginal(Paragraph::fromString("Synced block content")),
             // TODO: Video
             // TODO: Audio
             ColumnList::create(
@@ -195,6 +197,35 @@ class BlocksTest extends TestCase
         $this->assertSame(Helper::testPageId(), $blocks[0]->pageId);
     }
 
+    public function test_add_synced_block(): void
+    {
+        $client = Helper::client();
+
+        $original = SyncedBlock::createOriginal(
+            Paragraph::fromString("Original synced content"),
+        );
+
+        $blocks = $client->blocks()->append(Helper::testPageId(), [$original]);
+        $originalBlock = $blocks[0];
+
+        $reference = SyncedBlock::createReference($originalBlock);
+        $refBlocks = $client->blocks()->append(Helper::testPageId(), [$reference]);
+        $referenceBlock = $refBlocks[0];
+
+        foreach (array_merge($blocks, $refBlocks) as $block) {
+            $client->blocks()->delete($block->metadata()->id);
+        }
+
+        $this->assertSame(BlockType::SyncedBlock, $originalBlock->metadata()->type);
+        $this->assertInstanceOf(SyncedBlock::class, $originalBlock);
+        $this->assertTrue($originalBlock->isOriginal());
+
+        $this->assertSame(BlockType::SyncedBlock, $referenceBlock->metadata()->type);
+        $this->assertInstanceOf(SyncedBlock::class, $referenceBlock);
+        $this->assertTrue($referenceBlock->isReference());
+        $this->assertSame($originalBlock->metadata()->id, $referenceBlock->originalBlockId());
+    }
+
     public function test_add_to_inexistent_block(): void
     {
         $client = Helper::client();
@@ -236,6 +267,7 @@ class BlocksTest extends TestCase
                 ToDo::fromString("To do item"),
                 Toggle::fromString("Toggle"),
                 LinkToPage::page(Helper::testPageId()),
+                SyncedBlock::createOriginal(Paragraph::fromString("Content")),
                 // TODO: Video
                 // TODO: ColumnList
             ]

--- a/tests/Unit/Blocks/SyncedBlockTest.php
+++ b/tests/Unit/Blocks/SyncedBlockTest.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace Notion\Test\Unit\Blocks;
+
+use Notion\Blocks\BlockFactory;
+use Notion\Blocks\BlockType;
+use Notion\Blocks\Paragraph;
+use Notion\Blocks\SyncedBlock;
+use Notion\Blocks\SyncedFrom;
+use Notion\Exceptions\BlockException;
+use PHPUnit\Framework\TestCase;
+
+class SyncedBlockTest extends TestCase
+{
+    public function test_create_original_without_children(): void
+    {
+        $block = SyncedBlock::createOriginal();
+
+        $this->assertSame(BlockType::SyncedBlock, $block->metadata()->type);
+        $this->assertTrue($block->isOriginal());
+        $this->assertFalse($block->isReference());
+        $this->assertNull($block->syncedFrom);
+        $this->assertNull($block->originalBlockId());
+        $this->assertEmpty($block->children);
+        $this->assertFalse($block->metadata()->hasChildren);
+        $this->assertFalse($block->metadata()->inTrash);
+    }
+
+    public function test_create_original_with_children(): void
+    {
+        $child = Paragraph::fromString("Synced block paragraph");
+        $block = SyncedBlock::createOriginal($child);
+
+        $this->assertTrue($block->isOriginal());
+        $this->assertCount(1, $block->children);
+        $this->assertSame($child, $block->children[0]);
+        $this->assertTrue($block->metadata()->hasChildren);
+    }
+
+    public function test_create_reference_from_string(): void
+    {
+        $block = SyncedBlock::createReference("89b25dc4-6b22-4467-8cfb-663806bf203e");
+
+        $this->assertSame(BlockType::SyncedBlock, $block->metadata()->type);
+        $this->assertFalse($block->isOriginal());
+        $this->assertTrue($block->isReference());
+        $this->assertNotNull($block->syncedFrom);
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $block->syncedFrom->blockId);
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $block->originalBlockId());
+        $this->assertEmpty($block->children);
+        $this->assertFalse($block->metadata()->hasChildren);
+    }
+
+    public function test_create_reference_from_synced_block(): void
+    {
+        $rawOriginal = [
+            "object"           => "block",
+            "id"               => "7af38973-3787-41b3-bd75-0ed3a1edfac9",
+            "created_time"     => "2021-11-17T22:17:00.000Z",
+            "last_edited_time" => "2021-11-17T22:17:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "synced_block",
+            "synced_block"     => [
+                "synced_from" => null,
+            ],
+        ];
+        $original = SyncedBlock::fromArray($rawOriginal);
+
+        $reference = SyncedBlock::createReference($original);
+
+        $this->assertTrue($reference->isReference());
+        $this->assertSame("7af38973-3787-41b3-bd75-0ed3a1edfac9", $reference->originalBlockId());
+    }
+
+    public function test_create_reference_from_reference_synced_block(): void
+    {
+        $ref1 = SyncedBlock::createReference("original-id-123");
+        $ref2 = SyncedBlock::createReference($ref1);
+
+        $this->assertTrue($ref2->isReference());
+        $this->assertSame("original-id-123", $ref2->originalBlockId());
+    }
+
+    public function test_add_child_on_original(): void
+    {
+        $block = SyncedBlock::createOriginal();
+        $child = Paragraph::fromString("Nested item");
+
+        $newBlock = $block->addChild($child);
+
+        $this->assertEmpty($block->children);
+        $this->assertCount(1, $newBlock->children);
+        $this->assertSame($child, $newBlock->children[0]);
+        $this->assertTrue($newBlock->metadata()->hasChildren);
+    }
+
+    public function test_change_children_on_original(): void
+    {
+        $block = SyncedBlock::createOriginal();
+        $child1 = Paragraph::fromString("Item 1");
+        $child2 = Paragraph::fromString("Item 2");
+
+        $newBlock = $block->changeChildren($child1, $child2);
+        $this->assertCount(2, $newBlock->children);
+        $this->assertTrue($newBlock->metadata()->hasChildren);
+
+        $emptyBlock = $newBlock->changeChildren();
+        $this->assertEmpty($emptyBlock->children);
+        $this->assertFalse($emptyBlock->metadata()->hasChildren);
+    }
+
+    public function test_add_child_on_reference_throws_exception(): void
+    {
+        $block = SyncedBlock::createReference("89b25dc4-6b22-4467-8cfb-663806bf203e");
+
+        $this->expectException(BlockException::class);
+        $block->addChild(Paragraph::fromString("Child"));
+    }
+
+    public function test_change_children_on_reference_throws_exception(): void
+    {
+        $block = SyncedBlock::createReference("89b25dc4-6b22-4467-8cfb-663806bf203e");
+
+        $this->expectException(BlockException::class);
+        $block->changeChildren(Paragraph::fromString("Child"));
+    }
+
+    public function test_change_synced_from(): void
+    {
+        $block = SyncedBlock::createReference("old-id");
+
+        $withString = $block->changeSyncedFrom("new-id-1");
+        $this->assertSame("new-id-1", $withString->originalBlockId());
+
+        $withObject = $block->changeSyncedFrom(SyncedFrom::create("new-id-2"));
+        $this->assertSame("new-id-2", $withObject->originalBlockId());
+    }
+
+    public function test_to_original(): void
+    {
+        $ref = SyncedBlock::createReference("original-id");
+        $child = Paragraph::fromString("New original child");
+
+        $original = $ref->toOriginal($child);
+
+        $this->assertTrue($original->isOriginal());
+        $this->assertFalse($original->isReference());
+        $this->assertNull($original->syncedFrom);
+        $this->assertCount(1, $original->children);
+        $this->assertTrue($original->metadata()->hasChildren);
+    }
+
+    public function test_to_reference(): void
+    {
+        $original = SyncedBlock::createOriginal(Paragraph::fromString("Child"));
+
+        $ref = $original->toReference("target-id");
+
+        $this->assertFalse($ref->isOriginal());
+        $this->assertTrue($ref->isReference());
+        $this->assertSame("target-id", $ref->originalBlockId());
+        $this->assertEmpty($ref->children);
+        $this->assertFalse($ref->metadata()->hasChildren);
+    }
+
+    public function test_to_reference_from_synced_from_and_synced_block(): void
+    {
+        $original = SyncedBlock::createOriginal();
+
+        $refFromObject = $original->toReference(SyncedFrom::create("target-1"));
+        $this->assertSame("target-1", $refFromObject->originalBlockId());
+
+        $refFromRef = $original->toReference($refFromObject);
+        $this->assertSame("target-1", $refFromRef->originalBlockId());
+    }
+
+    public function test_from_array_original_with_children(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "7af38973-3787-41b3-bd75-0ed3a1edfac9",
+            "created_time"     => "2021-11-17T22:17:00.000Z",
+            "last_edited_time" => "2021-11-17T22:17:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => true,
+            "type"             => "synced_block",
+            "synced_block"     => [
+                "synced_from" => null,
+                "children"    => [
+                    [
+                        "object"           => "block",
+                        "id"               => "89b25dc4-6b22-4467-8cfb-663806bf203e",
+                        "created_time"     => "2021-11-17T22:17:00.000Z",
+                        "last_edited_time" => "2021-11-17T22:17:00.000Z",
+                        "in_trash"         => false,
+                        "has_children"     => false,
+                        "type"             => "paragraph",
+                        "paragraph"        => [
+                            "rich_text" => [
+                                [
+                                    "type"        => "text",
+                                    "text"        => [ "content" => "Child content", "link" => null ],
+                                    "annotations" => [
+                                        "bold"          => false,
+                                        "italic"        => false,
+                                        "strikethrough" => false,
+                                        "underline"     => false,
+                                        "code"          => false,
+                                        "color"         => "default",
+                                    ],
+                                    "plain_text"  => "Child content",
+                                    "href"        => null,
+                                ],
+                            ],
+                            "color"     => "default",
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $block = SyncedBlock::fromArray($array);
+
+        $this->assertTrue($block->isOriginal());
+        $this->assertNull($block->syncedFrom);
+        $this->assertCount(1, $block->children);
+        $this->assertInstanceOf(Paragraph::class, $block->children[0]);
+        $this->assertSame("Child content", $block->children[0]->toString());
+
+        $this->assertEquals($block, BlockFactory::fromArray($array));
+    }
+
+    public function test_from_array_original_without_children_key(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "7af38973-3787-41b3-bd75-0ed3a1edfac9",
+            "created_time"     => "2021-11-17T22:17:00.000Z",
+            "last_edited_time" => "2021-11-17T22:17:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "synced_block",
+            "synced_block"     => [
+                "synced_from" => null,
+            ],
+        ];
+
+        $block = SyncedBlock::fromArray($array);
+
+        $this->assertTrue($block->isOriginal());
+        $this->assertEmpty($block->children);
+    }
+
+    public function test_from_array_reference(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "7af38973-3787-41b3-bd75-0ed3a1edfac9",
+            "created_time"     => "2021-11-17T22:17:00.000Z",
+            "last_edited_time" => "2021-11-17T22:17:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => true,
+            "type"             => "synced_block",
+            "synced_block"     => [
+                "synced_from" => [
+                    "type"     => "block_id",
+                    "block_id" => "89b25dc4-6b22-4467-8cfb-663806bf203e",
+                ],
+            ],
+        ];
+
+        $block = SyncedBlock::fromArray($array);
+
+        $this->assertTrue($block->isReference());
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $block->originalBlockId());
+        $this->assertEmpty($block->children);
+
+        $this->assertEquals($block, BlockFactory::fromArray($array));
+    }
+
+    public function test_to_array_original(): void
+    {
+        $child = Paragraph::fromString("Child");
+        $block = SyncedBlock::createOriginal($child);
+
+        $array = $block->toArray();
+
+        $this->assertSame("block", $array["object"]);
+        $this->assertSame("synced_block", $array["type"]);
+        $this->assertArrayHasKey("synced_block", $array);
+
+        /** @var array{ synced_from: mixed, children: list<array{ type: string, ... }> } $syncedBlock */
+        $syncedBlock = $array["synced_block"];
+        $this->assertNull($syncedBlock["synced_from"]);
+        $this->assertCount(1, $syncedBlock["children"]);
+        $this->assertSame("paragraph", $syncedBlock["children"][0]["type"]);
+    }
+
+    public function test_to_array_reference(): void
+    {
+        $block = SyncedBlock::createReference("89b25dc4-6b22-4467-8cfb-663806bf203e");
+
+        $array = $block->toArray();
+
+        $this->assertSame("block", $array["object"]);
+        $this->assertSame("synced_block", $array["type"]);
+        $this->assertArrayHasKey("synced_block", $array);
+
+        /** @var array{ synced_from: array{ type: string, block_id: string }, children?: mixed } $syncedBlock */
+        $syncedBlock = $array["synced_block"];
+        $this->assertSame(
+            [
+                "type"     => "block_id",
+                "block_id" => "89b25dc4-6b22-4467-8cfb-663806bf203e",
+            ],
+            $syncedBlock["synced_from"]
+        );
+        $this->assertArrayNotHasKey("children", $syncedBlock);
+    }
+
+    public function test_delete(): void
+    {
+        $block = SyncedBlock::createOriginal();
+
+        $deleted = $block->delete();
+        $this->assertTrue($deleted->metadata()->inTrash);
+    }
+
+    public function test_archive(): void
+    {
+        $block = SyncedBlock::createOriginal();
+
+        /** @psalm-suppress DeprecatedMethod */
+        $archived = $block->archive();
+        $this->assertTrue($archived->metadata()->inTrash);
+    }
+
+    public function test_wrong_type_throws_exception(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "7af38973-3787-41b3-bd75-0ed3a1edfac9",
+            "created_time"     => "2021-11-17T22:17:00.000Z",
+            "last_edited_time" => "2021-11-17T22:17:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "paragraph",
+            "synced_block"     => [
+                "synced_from" => null,
+            ],
+        ];
+
+        $this->expectException(BlockException::class);
+        SyncedBlock::fromArray($array);
+    }
+}

--- a/tests/Unit/Blocks/SyncedFromTest.php
+++ b/tests/Unit/Blocks/SyncedFromTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Notion\Test\Unit\Blocks;
+
+use Notion\Blocks\SyncedFrom;
+use PHPUnit\Framework\TestCase;
+
+class SyncedFromTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $from = SyncedFrom::create("89b25dc4-6b22-4467-8cfb-663806bf203e");
+
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $from->blockId);
+        $this->assertSame("block_id", $from->type);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "type"     => "block_id",
+            "block_id" => "89b25dc4-6b22-4467-8cfb-663806bf203e",
+        ];
+        $from = SyncedFrom::fromArray($array);
+
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $from->blockId);
+        $this->assertSame("block_id", $from->type);
+    }
+
+    public function test_from_array_without_type(): void
+    {
+        $array = [
+            "block_id" => "89b25dc4-6b22-4467-8cfb-663806bf203e",
+        ];
+        $from = SyncedFrom::fromArray($array);
+
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $from->blockId);
+        $this->assertSame("block_id", $from->type);
+    }
+
+    public function test_to_array(): void
+    {
+        $from = SyncedFrom::create("89b25dc4-6b22-4467-8cfb-663806bf203e");
+        $expected = [
+            "type"     => "block_id",
+            "block_id" => "89b25dc4-6b22-4467-8cfb-663806bf203e",
+        ];
+
+        $this->assertSame($expected, $from->toArray());
+    }
+
+    public function test_change_block_id(): void
+    {
+        $from = SyncedFrom::create("89b25dc4-6b22-4467-8cfb-663806bf203e");
+        $new = $from->changeBlockId("d368e7d2-9706-4fc6-bca5-bdf95db0f2b2");
+
+        $this->assertSame("d368e7d2-9706-4fc6-bca5-bdf95db0f2b2", $new->blockId);
+        $this->assertSame("89b25dc4-6b22-4467-8cfb-663806bf203e", $from->blockId);
+    }
+}


### PR DESCRIPTION
Closes #449

## Summary

Support `synced_block` blocks in accordance with Notion API specifications:

- Add `SyncedBlock` case to `BlockType` enum.
- Add `SyncedFrom` model representing the `synced_from` reference object.
- Add `SyncedBlock` block model implementing `BlockInterface`, with typed factory methods (`createOriginal`, `createReference`, `fromArray`), type query assertions (`isOriginal`, `isReference`), helper accessors (`originalBlockId`), children handling on original blocks (`addChild`, `changeChildren`), reference modification & transitions (`changeSyncedFrom`, `toOriginal`, `toReference`), and request serialization/deserialization.
- Register `BlockType::SyncedBlock` in `BlockFactory`.
- Add documentation in `docs/blocks/SyncedBlock.md` and update `docs/blocks/index.md`.
- Document changes in `CHANGELOG.md`.
- Add comprehensive unit tests in `SyncedBlockTest` and `SyncedFromTest`.
- Add integration tests in `tests/Integration/BlocksTest.php`.