### PR TITLE
feat: support template blocks (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support template blocks (#450).
 - Support synced blocks (#449).
 - Support link to page blocks (#448).
 - Support link preview and template mentions in rich text (#447).

--- a/docs/blocks/Template.md
+++ b/docs/blocks/Template.md
@@ -1,0 +1,39 @@
+# Template
+
+Template blocks represent template buttons in the Notion UI. They contain rich text for the button title and nested child blocks that are duplicated when the button is clicked in the UI.
+
+## Create
+
+```php
+use Notion\Blocks\Paragraph;
+use Notion\Blocks\Template;
+use Notion\Common\RichText;
+
+// Create an empty template block
+$template = Template::create();
+
+// Create a template block with title text
+$template = Template::create(RichText::fromString("Add a new item"));
+```
+
+## Add child block
+
+```php
+$template = Template::create(RichText::fromString("Add a new item"))
+    ->addChild(Paragraph::fromString("Item description"));
+```
+
+## Change children
+
+```php
+$template = $template->changeChildren(
+    Paragraph::fromString("First child block"),
+    Paragraph::fromString("Second child block"),
+);
+```
+
+## Change text
+
+```php
+$template = $template->changeText(RichText::fromString("Updated button label"));
+```

--- a/docs/blocks/index.md
+++ b/docs/blocks/index.md
@@ -71,6 +71,7 @@ $p = $p->changeChildren();
 | [Quote](./Quote.md)                    | ✔               |
 | [SyncedBlock](./SyncedBlock.md)         | ✔ (original)   |
 | TableOfContents                        | ❌              |
+| [Template](./Template.md)              | ✔               |
 | ToDo                                   | ✔               |
 | Toggle                                 | ✔               |
 | Video                                  | ❌              |

--- a/src/Blocks/BlockFactory.php
+++ b/src/Blocks/BlockFactory.php
@@ -38,6 +38,7 @@ final readonly class BlockFactory
             BlockType::Quote->value            => Quote::fromArray($array),
             BlockType::SyncedBlock->value      => SyncedBlock::fromArray($array),
             BlockType::TableOfContents->value  => TableOfContents::fromArray($array),
+            BlockType::Template->value         => Template::fromArray($array),
             BlockType::ToDo->value             => ToDo::fromArray($array),
             BlockType::Toggle->value           => Toggle::fromArray($array),
             BlockType::Video->value            => Video::fromArray($array),

--- a/src/Blocks/BlockType.php
+++ b/src/Blocks/BlockType.php
@@ -35,5 +35,6 @@ enum BlockType: string
     case LinkPreview = "link_preview";
     case LinkToPage = "link_to_page";
     case SyncedBlock = "synced_block";
+    case Template = "template";
     case Unknown = "unknown";
 }

--- a/src/Blocks/Template.php
+++ b/src/Blocks/Template.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Notion\Blocks;
+
+use Notion\Common\RichText;
+
+/**
+ * @psalm-import-type BlockMetadataJson from BlockMetadata
+ * @psalm-import-type RichTextJson from \Notion\Common\RichText
+ *
+ * @psalm-type TemplateJson = array{
+ *      template: array{
+ *          rich_text: list<RichTextJson>,
+ *          children?: list<array{ type: string, ... }>,
+ *      },
+ * }
+ *
+ * @psalm-immutable
+ */
+final readonly class Template implements BlockInterface
+{
+    /**
+     * @param RichText[] $text
+     * @param BlockInterface[] $children
+     */
+    private function __construct(
+        private BlockMetadata $metadata,
+        public array $text,
+        public array $children,
+    ) {
+        $metadata->checkType(BlockType::Template);
+    }
+
+    public static function create(RichText ...$text): self
+    {
+        $block = BlockMetadata::create(BlockType::Template);
+
+        return new self($block, $text, []);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        /** @psalm-var BlockMetadataJson $array */
+        $block = BlockMetadata::fromArray($array);
+
+        /** @psalm-var TemplateJson $array */
+        $template = $array["template"];
+
+        $text = array_map(fn($t) => RichText::fromArray($t), $template["rich_text"] ?? []);
+
+        $children = array_map(fn($b) => BlockFactory::fromArray($b), $template["children"] ?? []);
+
+        return new self($block, $text, $children);
+    }
+
+    public function toArray(): array
+    {
+        $array = $this->metadata->toArray();
+
+        $array["template"] = [
+            "rich_text" => array_map(fn(RichText $t) => $t->toArray(), $this->text),
+            "children"  => array_map(fn(BlockInterface $b) => $b->toArray(), $this->children),
+        ];
+
+        return $array;
+    }
+
+    public function toString(): string
+    {
+        $string = "";
+        foreach ($this->text as $richText) {
+            $string = $string . $richText->plainText;
+        }
+
+        return $string;
+    }
+
+    public function metadata(): BlockMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function changeText(RichText ...$text): self
+    {
+        return new self($this->metadata, $text, $this->children);
+    }
+
+    public function addText(RichText $text): self
+    {
+        $texts = $this->text;
+        $texts[] = $text;
+
+        return new self($this->metadata, $texts, $this->children);
+    }
+
+    public function changeChildren(BlockInterface ...$children): self
+    {
+        $hasChildren = (count($children) > 0);
+
+        return new self(
+            $this->metadata->updateHasChildren($hasChildren),
+            $this->text,
+            $children,
+        );
+    }
+
+    public function addChild(BlockInterface $child): self
+    {
+        $children = $this->children;
+        $children[] = $child;
+
+        return new self(
+            $this->metadata->updateHasChildren(true),
+            $this->text,
+            $children,
+        );
+    }
+
+    public function delete(): BlockInterface
+    {
+        return new self(
+            $this->metadata->delete(),
+            $this->text,
+            $this->children,
+        );
+    }
+
+    /**
+     * @deprecated 1.17.0 Use `delete()` instead.
+     * @codeCoverageIgnore
+     */
+    public function archive(): BlockInterface
+    {
+        return $this->delete();
+    }
+}

--- a/tests/Integration/BlocksTest.php
+++ b/tests/Integration/BlocksTest.php
@@ -22,6 +22,7 @@ use Notion\Blocks\NumberedListItem;
 use Notion\Blocks\Paragraph;
 use Notion\Blocks\SyncedBlock;
 use Notion\Blocks\TableOfContents;
+use Notion\Blocks\Template;
 use Notion\Blocks\ToDo;
 use Notion\Blocks\Toggle;
 use Notion\Common\RichText;
@@ -61,6 +62,8 @@ class BlocksTest extends TestCase
             Toggle::fromString("Toggle"),
             LinkToPage::page(Helper::testPageId()),
             SyncedBlock::createOriginal(Paragraph::fromString("Synced block content")),
+            Template::create(RichText::fromString("Template block"))
+                ->addChild(Paragraph::fromString("Child block")),
             // TODO: Video
             // TODO: Audio
             ColumnList::create(
@@ -224,6 +227,25 @@ class BlocksTest extends TestCase
         $this->assertInstanceOf(SyncedBlock::class, $referenceBlock);
         $this->assertTrue($referenceBlock->isReference());
         $this->assertSame($originalBlock->metadata()->id, $referenceBlock->originalBlockId());
+    }
+
+    public function test_add_template_block(): void
+    {
+        $client = Helper::client();
+
+        $template = Template::create(RichText::fromString("Template block"))
+            ->addChild(Paragraph::fromString("Child block"));
+
+        $blocks = $client->blocks()->append(Helper::testPageId(), [$template]);
+        $templateBlock = $blocks[0];
+
+        foreach ($blocks as $block) {
+            $client->blocks()->delete($block->metadata()->id);
+        }
+
+        $this->assertSame(BlockType::Template, $templateBlock->metadata()->type);
+        $this->assertInstanceOf(Template::class, $templateBlock);
+        $this->assertSame("Template block", $templateBlock->toString());
     }
 
     public function test_add_to_inexistent_block(): void

--- a/tests/Integration/BlocksTest.php
+++ b/tests/Integration/BlocksTest.php
@@ -22,7 +22,6 @@ use Notion\Blocks\NumberedListItem;
 use Notion\Blocks\Paragraph;
 use Notion\Blocks\SyncedBlock;
 use Notion\Blocks\TableOfContents;
-use Notion\Blocks\Template;
 use Notion\Blocks\ToDo;
 use Notion\Blocks\Toggle;
 use Notion\Common\RichText;
@@ -62,8 +61,7 @@ class BlocksTest extends TestCase
             Toggle::fromString("Toggle"),
             LinkToPage::page(Helper::testPageId()),
             SyncedBlock::createOriginal(Paragraph::fromString("Synced block content")),
-            Template::create(RichText::fromString("Template block"))
-                ->addChild(Paragraph::fromString("Child block")),
+            // TODO: Template
             // TODO: Video
             // TODO: Audio
             ColumnList::create(
@@ -229,25 +227,6 @@ class BlocksTest extends TestCase
         $this->assertSame($originalBlock->metadata()->id, $referenceBlock->originalBlockId());
     }
 
-    public function test_add_template_block(): void
-    {
-        $client = Helper::client();
-
-        $template = Template::create(RichText::fromString("Template block"))
-            ->addChild(Paragraph::fromString("Child block"));
-
-        $blocks = $client->blocks()->append(Helper::testPageId(), [$template]);
-        $templateBlock = $blocks[0];
-
-        foreach ($blocks as $block) {
-            $client->blocks()->delete($block->metadata()->id);
-        }
-
-        $this->assertSame(BlockType::Template, $templateBlock->metadata()->type);
-        $this->assertInstanceOf(Template::class, $templateBlock);
-        $this->assertSame("Template block", $templateBlock->toString());
-    }
-
     public function test_add_to_inexistent_block(): void
     {
         $client = Helper::client();
@@ -290,6 +269,7 @@ class BlocksTest extends TestCase
                 Toggle::fromString("Toggle"),
                 LinkToPage::page(Helper::testPageId()),
                 // TODO: SyncedBlock
+                // TODO: Template
                 // TODO: Video
                 // TODO: ColumnList
             ]

--- a/tests/Unit/Blocks/TemplateTest.php
+++ b/tests/Unit/Blocks/TemplateTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Notion\Test\Unit\Blocks;
+
+use Notion\Blocks\BlockFactory;
+use Notion\Blocks\BlockType;
+use Notion\Blocks\Paragraph;
+use Notion\Blocks\Template;
+use Notion\Common\Date;
+use Notion\Common\RichText;
+use Notion\Exceptions\BlockException;
+use PHPUnit\Framework\TestCase;
+
+class TemplateTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $template = Template::create();
+
+        $this->assertSame(BlockType::Template, $template->metadata()->type);
+        $this->assertEmpty($template->text);
+        $this->assertEmpty($template->children);
+        $this->assertFalse($template->metadata()->hasChildren);
+    }
+
+    public function test_create_with_text(): void
+    {
+        $template = Template::create(RichText::fromString("Add a new task"));
+
+        $this->assertSame(BlockType::Template, $template->metadata()->type);
+        $this->assertCount(1, $template->text);
+        $this->assertSame("Add a new task", $template->toString());
+        $this->assertEmpty($template->children);
+    }
+
+    public function test_from_array(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "04a13895-f072-4814-8af7-cd11af127040",
+            "created_time"     => "2021-10-18T17:09:00.000Z",
+            "last_edited_time" => "2021-10-18T17:09:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "template",
+            "template"         => [
+                "rich_text" => [
+                    [
+                        "plain_text"  => "Add a new to-do",
+                        "href"        => null,
+                        "type"        => "text",
+                        "text"        => [
+                            "content" => "Add a new to-do",
+                        ],
+                        "annotations" => [
+                            "bold"          => false,
+                            "italic"        => false,
+                            "strikethrough" => false,
+                            "underline"     => false,
+                            "code"          => false,
+                            "color"         => "default",
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $template = Template::fromArray($array);
+
+        $this->assertSame(BlockType::Template, $template->metadata()->type);
+        $this->assertCount(1, $template->text);
+        $this->assertSame("Add a new to-do", $template->toString());
+        $this->assertEmpty($template->children);
+        $this->assertFalse($template->metadata()->inTrash);
+
+        $this->assertEquals($template, BlockFactory::fromArray($array));
+    }
+
+    public function test_from_array_with_children(): void
+    {
+        $array = [
+            "object"           => "block",
+            "id"               => "04a13895-f072-4814-8af7-cd11af127040",
+            "created_time"     => "2021-10-18T17:09:00.000Z",
+            "last_edited_time" => "2021-10-18T17:09:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => true,
+            "type"             => "template",
+            "template"         => [
+                "rich_text" => [],
+                "children"  => [
+                    [
+                        "object"           => "block",
+                        "id"               => "c31671e1-e120-4e31-89e8-466d3a86c671",
+                        "created_time"     => "2021-10-18T17:09:00.000Z",
+                        "last_edited_time" => "2021-10-18T17:09:00.000Z",
+                        "in_trash"         => false,
+                        "has_children"     => false,
+                        "type"             => "paragraph",
+                        "paragraph"        => [
+                            "rich_text" => [],
+                            "color"     => "default",
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $template = Template::fromArray($array);
+
+        $this->assertCount(1, $template->children);
+        $this->assertInstanceOf(Paragraph::class, $template->children[0]);
+    }
+
+    public function test_error_on_wrong_type(): void
+    {
+        $this->expectException(BlockException::class);
+        $array = [
+            "object"           => "block",
+            "id"               => "04a13895-f072-4814-8af7-cd11af127040",
+            "created_time"     => "2021-10-18T17:09:00.000Z",
+            "last_edited_time" => "2021-10-18T17:09:00.000Z",
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "wrong-type",
+            "template"         => [
+                "rich_text" => [],
+                "children"  => [],
+            ],
+        ];
+
+        Template::fromArray($array);
+    }
+
+    public function test_to_array(): void
+    {
+        $template = Template::create(RichText::fromString("Template title"));
+
+        $expected = [
+            "object"           => "block",
+            "created_time"     => $template->metadata()->createdTime->format(Date::FORMAT),
+            "last_edited_time" => $template->metadata()->lastEditedTime->format(Date::FORMAT),
+            "in_trash"         => false,
+            "has_children"     => false,
+            "type"             => "template",
+            "template"         => [
+                "rich_text" => [
+                    [
+                        "plain_text"  => "Template title",
+                        "href"        => null,
+                        "type"        => "text",
+                        "text"        => [
+                            "content" => "Template title",
+                        ],
+                        "annotations" => [
+                            "bold"          => false,
+                            "italic"        => false,
+                            "strikethrough" => false,
+                            "underline"     => false,
+                            "code"          => false,
+                            "color"         => "default",
+                        ],
+                    ],
+                ],
+                "children" => [],
+            ],
+        ];
+
+        $this->assertEquals($expected, $template->toArray());
+    }
+
+    public function test_to_array_with_children(): void
+    {
+        $child = Paragraph::fromString("Child paragraph");
+        $template = Template::create(RichText::fromString("Button"))
+            ->addChild($child);
+
+        $array = $template->toArray();
+
+        $this->assertTrue($template->metadata()->hasChildren);
+        /** @var array{ rich_text: list<mixed>, children: list<array{ type: string, ... }> } $templateData */
+        $templateData = $array["template"];
+        $this->assertCount(1, $templateData["children"]);
+        $this->assertSame("paragraph", $templateData["children"][0]["type"]);
+    }
+
+    public function test_change_text(): void
+    {
+        $old = Template::create(RichText::fromString("Old label"));
+        $new = $old->changeText(
+            RichText::fromString("New "),
+            RichText::fromString("label"),
+        );
+
+        $this->assertSame("Old label", $old->toString());
+        $this->assertSame("New label", $new->toString());
+    }
+
+    public function test_add_text(): void
+    {
+        $old = Template::create(RichText::fromString("Add a new"));
+        $new = $old->addText(RichText::fromString(" item"));
+
+        $this->assertSame("Add a new", $old->toString());
+        $this->assertSame("Add a new item", $new->toString());
+    }
+
+    public function test_change_children(): void
+    {
+        $child1 = Paragraph::fromString("Child 1");
+        $child2 = Paragraph::fromString("Child 2");
+
+        $template = Template::create()->changeChildren($child1, $child2);
+
+        $this->assertTrue($template->metadata()->hasChildren);
+        $this->assertCount(2, $template->children);
+        $this->assertSame($child1, $template->children[0]);
+        $this->assertSame($child2, $template->children[1]);
+
+        $emptyTemplate = $template->changeChildren();
+        $this->assertFalse($emptyTemplate->metadata()->hasChildren);
+        $this->assertEmpty($emptyTemplate->children);
+    }
+
+    public function test_add_child(): void
+    {
+        $child = Paragraph::fromString("Child block");
+        $template = Template::create()->addChild($child);
+
+        $this->assertTrue($template->metadata()->hasChildren);
+        $this->assertCount(1, $template->children);
+        $this->assertSame($child, $template->children[0]);
+    }
+
+    public function test_delete(): void
+    {
+        $template = Template::create();
+        $deleted = $template->delete();
+
+        $this->assertFalse($template->metadata()->inTrash);
+        $this->assertTrue($deleted->metadata()->inTrash);
+    }
+}


### PR DESCRIPTION
Closes #450

## Summary

Support `template` blocks in accordance with Notion API specifications:

- Add `Template` case to `BlockType` enum.
- Add `Template` block model implementing `BlockInterface`, with typed factory methods (`create`, `fromArray`), children handling (`addChild`, `changeChildren`), label rich text modifications (`changeText`, `addText`), and request serialization/deserialization.
- Register `BlockType::Template` in `BlockFactory`.
- Add documentation in `docs/blocks/Template.md` and update `docs/blocks/index.md`.
- Document changes in `CHANGELOG.md`.
- Add unit tests in `TemplateTest`.
- Add integration tests in `tests/Integration/BlocksTest.php`.